### PR TITLE
feat: add Cursor plugin support

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "wingspan-marketplace",
+  "owner": {
+    "name": "Very Good Ventures"
+  },
+  "metadata": {
+    "description": "Wingspan - AI-native workflows for Flutter and Dart following Very Good Ventures best practices.",
+    "version": "0.0.1"
+  },
+  "plugins": [
+    {
+      "name": "wingspan",
+      "source": "plugins/wingspan",
+      "description": "Wingspan - AI-native workflows for Flutter and Dart following Very Good Ventures best practices."
+    }
+  ]
+}

--- a/plugins/wingspan/.cursor-plugin/plugin.json
+++ b/plugins/wingspan/.cursor-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "wingspan",
+  "description": "Wingspan - AI-native workflows for Flutter and Dart following Very Good Ventures best practices.",
+  "version": "0.0.1",
+  "author": {
+    "name": "Very Good Ventures"
+  },
+  "homepage": "https://github.com/VeryGoodOpenSource/wingspan",
+  "repository": "https://github.com/VeryGoodOpenSource/wingspan",
+  "keywords": [
+    "flutter",
+    "dart",
+    "best practices",
+    "flow automation",
+    "code generation",
+    "planning",
+    "ai assisted engineering"
+  ]
+}


### PR DESCRIPTION
## Summary
Adds Cursor plugin support alongside the existing Claude plugin so the repo can be installed and used in Cursor (IDE, CLI, Cloud).

## Changes
- **`.cursor-plugin/marketplace.json`** (repo root) — Marketplace manifest so Cursor discovers the wingspan plugin when installing from this repo.
- **`plugins/wingspan/.cursor-plugin/plugin.json`** — Per-plugin manifest with name, description, version, author, keywords, homepage, and repository.

## Notes
- No changes to existing skills, agents, or MCP config; Cursor uses the same folder layout and frontmatter.
- Structure checks (large files, SKILL line limits) pass. No Dart in repo; markdown lint/spell check only target `**/*.md`` (unchanged).

Made with [Cursor](https://cursor.com)