### PR TITLE
bug: change artifacts directory to docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,8 @@ Quality-review agents:
 
 ## Output Directories
 
-- `wingspan/brainstorms/` — Brainstorm documents from `/ideate`
-- `wingspan/plans/` — Implementation plans from `/plan`
+- `docs/ideate/` — Brainstorm documents from `/ideate`
+- `docs/plan/` — Implementation plans from `/plan`
 
 ## Key Conventions
 

--- a/plugins/wingspan/skills/build/SKILL.md
+++ b/plugins/wingspan/skills/build/SKILL.md
@@ -5,7 +5,7 @@ description: Execute an implementation plan — write code and tests and run qua
 
 # Execute an implementation plan
 
-Take a plan from `wingspan/plans/` and turn it into shipped code: implement features, write tests, and validate quality.
+Take a plan from `docs/plan/` and turn it into shipped code: implement features, write tests, and validate quality.
 
 ## Plan Input
 
@@ -18,13 +18,13 @@ Take a plan from `wingspan/plans/` and turn it into shipped code: implement feat
 1. List available plans:
 
 ```bash
-ls -la wingspan/plans/*.md 2>/dev/null | head -20
+ls -la docs/plan/*.md 2>/dev/null | head -20
 ```
 
 Then:
 
 1. If plans exist, use **AskUserQuestion** to ask which plan to execute, listing each plan filename with a brief summary from the first heading.
-2. If no plans exist, tell the user: "No plans found in `wingspan/plans/`. Run `/plan` first to create an implementation plan."
+2. If no plans exist, tell the user: "No plans found in `docs/plan/`. Run `/plan` first to create an implementation plan."
 
 Do not proceed without a plan.
 

--- a/plugins/wingspan/skills/ideate/SKILL.md
+++ b/plugins/wingspan/skills/ideate/SKILL.md
@@ -107,9 +107,9 @@ Use **AskUserQuestion tool** to ask which approach the user prefers.
 
 ### 2. Capture the design document
 
-Write a brainstorm document to `wingspan/brainstorms/YYYY-MM-DD-<kebab-case-topic>-brainstorm-doc.md`.
+Write a brainstorm document to `docs/ideate/YYYY-MM-DD-<kebab-case-topic>-brainstorm-doc.md`.
 
-Ensure `wingspan/brainstorms/` directory exists before writing.
+Ensure `docs/ideate/` directory exists before writing.
 
 **Document structure:**
 
@@ -160,7 +160,7 @@ When complete, display:
 ```md
 Brainstorm complete!
 
-Document: wingspan/brainstorms/YYYY-MM-DD-<kebab-case-topic>-brainstorm-doc.md
+Document: docs/ideate/YYYY-MM-DD-<kebab-case-topic>-brainstorm-doc.md
 
 Key decisions:
 - [Decision 1]

--- a/plugins/wingspan/skills/plan/SKILL.md
+++ b/plugins/wingspan/skills/plan/SKILL.md
@@ -19,10 +19,10 @@ Do not proceed until you have a clear feature description from the user.
 
 **Check for brainstorm output first:**
 
-Before asking questions, look for recent brainstorm documents in `wingspan/brainstorms/` that match this feature:
+Before asking questions, look for recent brainstorm documents in `docs/ideate` that match this feature:
 
 ```bash
-ls -la wingspan/brainstorms/*.md 2>/dev/null | head -10
+ls -la docs/ideate/*.md 2>/dev/null | head -10
 ```
 
 **Relevance criteria:** A brainstorm is relevant if:
@@ -211,17 +211,17 @@ Use the `implementation-detail-levels/extensive.md` template for this level.
 
 ## Output Format
 
-**Filename:** Use the date and kebab-case filename from Step 2 Title & Categorization: `wingspan/plans/YYYY-MM-DD-<type>-<descriptive-name>-plan.md`
+**Filename:** Use the date and kebab-case filename from Step 2 Title & Categorization: `docs/plan/YYYY-MM-DD-<type>-<descriptive-name>-plan.md`
 
 Examples:
 
-- ✅ `wingspan/plans/2026-01-15-feat-user-authentication-flow-plan.md`
-- ✅ `wingspan/plans/2026-02-03-fix-checkout-race-condition-plan.md`
-- ✅ `wingspan/plans/2026-03-10-refactor-api-client-extraction-plan.md`
-- ❌ `wingspan/plans/2026-01-15-feat-thing-plan.md` (not descriptive - what "thing"?)
-- ❌ `wingspan/plans/2026-01-15-feat-new-feature-plan.md` (too vague - what feature?)
-- ❌ `wingspan/plans/2026-01-15-feat: user auth-plan.md` (invalid characters - colon and space)
-- ❌ `wingspan/plans/feat-user-auth-plan.md` (missing date prefix)
+- ✅ `docs/plan/2026-01-15-feat-user-authentication-flow-plan.md`
+- ✅ `docs/plan/2026-02-03-fix-checkout-race-condition-plan.md`
+- ✅ `docs/plan/2026-03-10-refactor-api-client-extraction-plan.md`
+- ❌ `docs/plan/2026-01-15-feat-thing-plan.md` (not descriptive - what "thing"?)
+- ❌ `docs/plan/2026-01-15-feat-new-feature-plan.md` (too vague - what feature?)
+- ❌ `docs/plan/2026-01-15-feat: user auth-plan.md` (invalid characters - colon and space)
+- ❌ `docs/plan/feat-user-auth-plan.md` (missing date prefix)
 
 ## Post-Generation Options
 
@@ -236,7 +236,7 @@ After writing the plan file, use the **AskUserQuestion tool** and present the fo
 
 Based on selection:
 
-- **Open plan in editor** → Run `open wingspan/plans/<plan_filename>.md` to open the file in the user's default editor
+- **Open plan in editor** → Run `open docs/plan/<plan_filename>.md` to open the file in the user's default editor
 - **`/plan-technical-review`** → Call the `/plan-technical-review` skill with the plan file path
 - **Review and refine** → Load `refine-approach` skill.
 - **Start building** → Call the `/build` skill with the plan file path

--- a/plugins/wingspan/skills/refine-approach/SKILL.md
+++ b/plugins/wingspan/skills/refine-approach/SKILL.md
@@ -11,7 +11,7 @@ Improve brainstorm and/or planning documents through structured review.
 
 **If a document is provided** then proceed to `Step 2. Assess`.
 
-**If no document is provided**, ask the user which document to review. Check `wingspan/brainstorms/` and `wingspan/plans/` for recent documents to suggest.
+**If no document is provided**, ask the user which document to review. Check `docs/ideate/` and `docs/plan/` for recent documents to suggest.
 
 ## Step 2. Assess
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description

- Favor `docs` instead of `wingspan`
- All subfolders match the name of the skill that created the artifact (`ideate`, `plan`)

Fixes #19 

## Type of Change

<!--- Check the one that applies to this PR. -->

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
