### PR TITLE
feat: agents full report vs summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.log
 node_modules/
+wingspan/reviews/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Quality-review agents:
 
 - `wingspan/brainstorms/` — Brainstorm documents from `/ideate`
 - `wingspan/plans/` — Implementation plans from `/plan`
+- `wingspan/reviews/` — Review reports from `/build`
 
 ## Key Conventions
 

--- a/plugins/wingspan/agents/codebase-review/code-simplicity-review-agent.md
+++ b/plugins/wingspan/agents/codebase-review/code-simplicity-review-agent.md
@@ -91,3 +91,12 @@ Recommended action: [Proceed with simplifications/Minor tweaks only/Already mini
 ```
 
 Remember: Perfect is the enemy of good. The simplest code that works is often the best code. Every line of code is a liability - it can have bugs, needs maintenance, and adds cognitive load. Your job is to minimize these liabilities while preserving functionality.
+
+## Output Instructions
+
+If a file path is specified in your task prompt, write your full review to that file path and return ONLY a brief summary to the caller covering:
+- Verdict (ready to merge / needs work / needs rethink)
+- Count of critical and important issues
+- One-line description of each critical issue
+
+If no file path is specified, return the full review in your response as usual.

--- a/plugins/wingspan/agents/codebase-review/vgv-review-agent.md
+++ b/plugins/wingspan/agents/codebase-review/vgv-review-agent.md
@@ -278,3 +278,12 @@ Remember these principles throughout every review:
 - **Simplicity is a feature.** The best code is the code you don't write. Question every addition.
 - **Code is read far more than it is written.** Optimize for the person reading this six months from now, not the person writing it today.
 - **Ship quality, not quantity.** VGV's reputation is built on engineering excellence. Every line of code we ship represents that reputation.
+
+## Output Instructions
+
+If a file path is specified in your task prompt, write your full review to that file path and return ONLY a brief summary to the caller covering:
+- Verdict (ready to merge / needs work / needs rethink)
+- Count of critical and important issues
+- One-line description of each critical issue
+
+If no file path is specified, return the full review in your response as usual.

--- a/plugins/wingspan/agents/quality-review/architecture-review-agent.md
+++ b/plugins/wingspan/agents/quality-review/architecture-review-agent.md
@@ -200,3 +200,12 @@ For each new or modified package, verify:
 - Dependencies flow one way. If you need something from a "lower" layer in a "higher" one, you have an abstraction problem.
 - Every package earns its existence. If a package has one file, it probably belongs in an existing package.
 - Flag violations with specific file paths and line numbers. Vague feedback is not actionable.
+
+## Output Instructions
+
+If a file path is specified in your task prompt, write your full review to that file path and return ONLY a brief summary to the caller covering:
+- Verdict (ready to merge / needs work / needs rethink)
+- Count of critical and important issues
+- One-line description of each critical issue
+
+If no file path is specified, return the full review in your response as usual.

--- a/plugins/wingspan/agents/quality-review/test-quality-review-agent.md
+++ b/plugins/wingspan/agents/quality-review/test-quality-review-agent.md
@@ -126,3 +126,12 @@ Flag these immediately:
 - `blocTest` and `mocktail` are the VGV standards. Other patterns need strong justification.
 - A test with no assertions is worse than no test — it inflates coverage metrics without catching bugs.
 - Test names are documentation. They should describe what the code does, not how it does it.
+
+## Output Instructions
+
+If a file path is specified in your task prompt, write your full review to that file path and return ONLY a brief summary to the caller covering:
+- Verdict (ready to merge / needs work / needs rethink)
+- Count of critical and important issues
+- One-line description of each critical issue
+
+If no file path is specified, return the full review in your response as usual.

--- a/plugins/wingspan/skills/build/SKILL.md
+++ b/plugins/wingspan/skills/build/SKILL.md
@@ -191,6 +191,14 @@ dart test
 
 If anything fails, fix it before proceeding.
 
+### Cleanup                                                                                       
+
+Remove the review reports — their findings have already been addressed or recorded:                                       
+
+```bash                                                                                     
+rm -rf docs/reviews/
+```
+
 ### Post-Ship
 
 Use **AskUserQuestion** to present options:

--- a/plugins/wingspan/skills/build/SKILL.md
+++ b/plugins/wingspan/skills/build/SKILL.md
@@ -133,7 +133,7 @@ Each agent prompt must include these instructions:
 > Write your full detailed report to `wingspan/reviews/<name>.md` (create the directory if needed).
 > Then return ONLY a short structured summary to the parent context in this format:
 >
-> ```
+> ```markdown
 > ## <Agent Name> Summary
 > **Report**: `wingspan/reviews/<name>.md` (<word_count> words)
 > **Critical**: <count> | **Important**: <count> | **Suggestions**: <count>

--- a/plugins/wingspan/skills/build/SKILL.md
+++ b/plugins/wingspan/skills/build/SKILL.md
@@ -124,27 +124,50 @@ After each logical unit of work:
 
 ## Phase 3 — Quality Review
 
-After all implementation tasks are complete, run 5 review agents **in parallel**:
+After all implementation tasks are complete, run 5 review agents **in parallel**.
 
-- **@vgv-review-agent** — VGV standards, conventions, and patterns
-- **@code-simplicity-review-agent** — YAGNI audit and simplification opportunities
-- **@test-quality-review-agent** — Test coverage and quality
-- **@architecture-review-agent** — Layer separation and Bloc/Cubit correctness
-- **@pr-readiness-review-agent** — Formatting, analysis, debug artifacts, commit hygiene
+### Agent instructions
 
-After all reviews complete:
+Each agent prompt must include these instructions:
 
-1. **Consolidate findings** into three categories:
+> Write your full detailed report to `wingspan/reviews/<name>.md` (create the directory if needed).
+> Then return ONLY a short structured summary to the parent context in this format:
+>
+> ```
+> ## <Agent Name> Summary
+> **Report**: `wingspan/reviews/<name>.md` (<word_count> words)
+> **Critical**: <count> | **Important**: <count> | **Suggestions**: <count>
+> ### Findings
+> - [Critical] <one-line description>
+> - [Important] <one-line description>
+> - [Suggestion] <one-line description>
+> ```
+>
+> Do NOT return the full report text. Only return the summary above.
+
+The 5 agents and their report filenames:
+
+| Agent | Report file |
+|-------|------------|
+| **@vgv-review-agent** | `wingspan/reviews/vgv-review.md` |
+| **@code-simplicity-review-agent** | `wingspan/reviews/code-simplicity-review.md` |
+| **@test-quality-review-agent** | `wingspan/reviews/test-quality-review.md` |
+| **@architecture-review-agent** | `wingspan/reviews/architecture-review.md` |
+| **@pr-readiness-review-agent** | `wingspan/reviews/pr-readiness-review.md` |
+
+### After all reviews complete
+
+1. **Consolidate findings** from all summaries into three categories:
    - **Critical** (must fix before merge): Bugs, missing tests, layer violations, broken analysis
    - **Important** (should fix): Convention deviations, test gaps, naming issues
    - **Suggestions** (note for PR): Style improvements, minor simplifications
 
 2. **Auto-fix minor issues**: formatting (`dart format`), missing `const`, lint warnings. Stage and commit fixes.
 
-3. **Fix critical issues**: Address each critical finding, re-run validation (`dart analyze`, `dart test`), and commit.
+3. **Fix critical issues**: Read the specific report file (e.g., `wingspan/reviews/architecture-review.md`) for full details on each critical finding. Address each one, re-run validation (`dart analyze`, `dart test`), and commit. Only read reports that contain critical issues — do not load all 5 reports into context.
 
 4. **Present important issues** to the user via **AskUserQuestion**:
-   - **Fix all**: address every important issue
+   - **Fix all**: address every important issue (read relevant report files for details)
    - **Review the list first**: show the full list for the user to decide
    - **Skip to shipping**: note them in the PR description instead
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description

<!--- Describe what changed and why. -->
Closes #31 

### How to test it
Create a simple Flutter project with `very_good create flutter_package my_app`. Add a wingspan plan `update-test-comment` that only changes a comment, we want to run Phase 1-2 really fast and only focus on Phase 3:
```
# Plan: Update test ignore comment

## Type
fix

## Summary
Make the `ignore_for_file` comment in `counter_page_test.dart` more descriptive.

## Acceptance Criteria
- The comment above `// ignore_for_file: prefer_const_constructors` explains *why* the lint is suppressed

## Tasks

### Task 1: Update the comment

**Files to modify:**
- `test/counter/view/counter_page_test.dart` — change `// Ignore for testing purposes` to `// Non-const constructors used intentionally in tests`
```
Then run in Claude the build skill for that plan:
`/wingspan:build wingspan/plans/update-test-comment.md `

At `wingspan/reviews/metrics_table.md` you will see the total words for summary vs full report, and the context saved (~96%). That should be the amount we could save into context when we run agents/skills

<img width="1206" height="338" alt="Screenshot 2026-02-25 at 13 22 36" src="https://github.com/user-attachments/assets/bf4bac5a-60c6-4348-a231-40aae2e9abf0" />


## Type of Change

<!--- Check the one that applies to this PR. -->

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
