### PR TITLE
refactor: rename ideate skill to brainstorm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Quality-review agents:
 ## Output Directories
 
 - `docs/brainstorms/` — Brainstorm documents from `/brainstorm`
-- `wingspan/plans/` — Implementation plans from `/plan`
+- `docs/plans/` — Implementation plans from `/plan`
 
 ## Key Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Apply VGV's best practices and standards for scalable Flutter apps to AI-assiste
 
 The plugin supports three phases:
 
-1. **`/ideate`** — Explore requirements and approaches through collaborative dialogue. Produces a brainstorm document.
+1. **`/brainstorm`** — Explore requirements and approaches through collaborative dialogue. Produces a brainstorm document.
 2. **`/plan`** — Transform brainstorm output into an actionable implementation plan. Includes codebase review, optional external research, and flow analysis.
 3. **`/build`** — Execute implementation plans: write code and tests, run quality review, and ship a pull request.
 
@@ -26,7 +26,7 @@ Quality-review agents:
 
 ## Output Directories
 
-- `wingspan/brainstorms/` — Brainstorm documents from `/ideate`
+- `wingspan/brainstorms/` — Brainstorm documents from `/brainstorm`
 - `wingspan/plans/` — Implementation plans from `/plan`
 
 ## Key Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Quality-review agents:
 
 ## Output Directories
 
-- `wingspan/brainstorms/` — Brainstorm documents from `/brainstorm`
+- `docs/brainstorms/` — Brainstorm documents from `/brainstorm`
 - `wingspan/plans/` — Implementation plans from `/plan`
 
 ## Key Conventions

--- a/plugins/wingspan/skills/brainstorm/SKILL.md
+++ b/plugins/wingspan/skills/brainstorm/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: ideate
+name: brainstorm
 description: Explore requirements and approaches through collaborative dialogue before planning implementation
 ---
 
-# Ideate and brainstorm a feature or improvement
+# Brainstorm a feature or improvement
 
 Clarify **WHAT** to build before diving into **HOW** to build it. Explore user intent, approaches, and design decisions through collaborative dialogue.
 
@@ -11,7 +11,7 @@ Clarify **WHAT** to build before diving into **HOW** to build it. Explore user i
 
 <feature description>$ARGUMENTS</feature description>
 
-**If the feature description above is empty, ask the user**: "What feature would you like to ideate? Describe the idea, problem or feature you are thinking about."
+**If the feature description above is empty, ask the user**: "What feature would you like to brainstorm? Describe the idea, problem or feature you are thinking about."
 
 DO NOT proceed until you have a description from the user.
 
@@ -139,12 +139,12 @@ topic: <kebab-case-topic>
 
 Use **AskUserQuestion tool** to consider next steps:
 
-**Question**: "Ideation complete! What would you like to do next?"
+**Question**: "Brainstorm complete! What would you like to do next?"
 
 **Options:**
 1. **Review and refine approach:** improve the document using structured review
 2. **Continue with planning**: run the `/plan` skill to create a detailed implementation plan
-3. **Done for now**: ideation complete. To start planning later: `/plan`
+3. **Done for now**: brainstorm complete. To start planning later: `/plan`
 
 **If the user selects "Review and refine approach"** then apply the @refine-approach skill to the document.
 

--- a/plugins/wingspan/skills/build/SKILL.md
+++ b/plugins/wingspan/skills/build/SKILL.md
@@ -50,7 +50,7 @@ Do not proceed until the user selects "Start building."
 
 ## Phase 1 — Setup
 
-**Do not run `codebase-review-agent` here.** The plan was already informed by codebase context from `/ideate` and `/plan`.
+**Do not run `codebase-review-agent` here.** The plan was already informed by codebase context from `/brainstorm` and `/plan`.
 
 Instead, use the plan itself as your guide:
 

--- a/plugins/wingspan/skills/plan/SKILL.md
+++ b/plugins/wingspan/skills/plan/SKILL.md
@@ -37,7 +37,7 @@ ls -la wingspan/brainstorms/*.md 2>/dev/null | head -10
 3. Extract key decisions, chosen approach, and open questions
 4. Use brainstorm decisions as input to the research phase
 
-**If no brainstorm found (or not relevant):** run @ideate to clarify the idea before proceeding.
+**If no brainstorm found (or not relevant):** run @brainstorm to clarify the idea before proceeding.
 
 **If multiple brainstorms found:** Use **AskUserQuestion tool** to ask which brainstorm to use, providing a brief summary of each candidate.
 
@@ -47,7 +47,7 @@ ls -la wingspan/brainstorms/*.md 2>/dev/null | head -10
 
 #### 1.1 Local research (always runs, and runs in parallel)
 
-**Do not re-run `codebase-review-agent` here.** Codebase context was already captured in the brainstorm from `/ideate`.
+**Do not re-run `codebase-review-agent` here.** Codebase context was already captured in the brainstorm from `/brainstorm`.
 
 Instead, extract what's needed from the brainstorm and run targeted searches:
 

--- a/plugins/wingspan/skills/refine-approach/SKILL.md
+++ b/plugins/wingspan/skills/refine-approach/SKILL.md
@@ -38,7 +38,7 @@ Apply the following criteria to evaluate the document:
 | **YAGNI** | No hypothetical features, simplest approach chosen |
 | **Scope** | Scope is well defined and constrained, not overly ambitious |
 
-If invoked during an ideation phase (after `/ideate`), validate that the document reflects with fidelity the user intent.
+If invoked during a brainstorm phase (after `/brainstorm`), validate that the document reflects with fidelity the user intent.
 
 ## Step 4. Critical improvements
 


### PR DESCRIPTION
## Summary

Renames the `ideate` skill to `brainstorm` for a 1:1 match between skill name and its output folder (`brainstorms/`).

Updates all references across `CLAUDE.md`, `plan`, `build`, and `refine-approach` skills.