### PR TITLE
feat: update installation instructions for plugin usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ AI-assisted workflows for Flutter and Dart that follow Very Good Ventures best p
 
 ## Installation
 
+### From the marketplace
+
 **Single session** — loads the plugin for the current session only:
 
 ```bash
@@ -19,9 +21,33 @@ claude --plugin VeryGoodOpenSource/wingspan
 cd /to/your/project
 claude
 # then inside Claude Code:
-/plugin install VeryGoodOpenSource/wingspan
+/plugin marketplace add VeryGoodOpenSource/wingspan
+/plugin install wingspan@wingspan-marketplace
 ```
 
-### Vision
+### For local development
+
+```bash
+git clone git@github.com:VeryGoodOpenSource/wingspan.git
+```
+
+**Single session** — loads the plugin for the current session only:
+
+```bash
+cd /to/your/project
+claude --plugin-dir <wingspan-path>/plugins/wingspan
+```
+
+**Persistent** — installs the plugin so it loads automatically on every session:
+
+```bash
+cd /to/your/project
+claude
+# then inside Claude Code:
+/plugin marketplace add <wingspan-path>
+/plugin install wingspan@wingspan-marketplace
+```
+
+## Vision
 
 ![wingspan vision](./assets/vision.png)

--- a/README.md
+++ b/README.md
@@ -6,17 +6,11 @@ AI-assisted workflows for Flutter and Dart that follow Very Good Ventures best p
 
 ## Installation
 
-### Local development
-
-```bash
-git clone git@github.com:VeryGoodOpenSource/wingspan.git
-```
-
 **Single session** — loads the plugin for the current session only:
 
 ```bash
 cd /to/your/project
-claude --plugin-dir <wingspan-path>/plugins/wingspan
+claude --plugin VeryGoodOpenSource/wingspan
 ```
 
 **Persistent** — installs the plugin so it loads automatically on every session:
@@ -25,8 +19,7 @@ claude --plugin-dir <wingspan-path>/plugins/wingspan
 cd /to/your/project
 claude
 # then inside Claude Code:
-/plugin marketplace add <wingspan-path>
-/plugin install wingspan@wingspan-marketplace
+/plugin install VeryGoodOpenSource/wingspan
 ```
 
 ### Vision


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description

Update installation instructions to use remote marketplace installation instead of cloning the repository and installing via local path. Users can now install Wingspan directly using the GitHub owner/repo identifier, removing the prerequisite of cloning the repo first.

## Type of Change

<!--- Check the one that applies to this PR. -->

- [ ] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [x] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)


