### PR TITLE
feat: add dart analyze post-edit hook

### DIFF
--- a/plugins/wingspan/hooks/hooks.json
+++ b/plugins/wingspan/hooks/hooks.json
@@ -7,6 +7,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/dart_analyze.sh",
+            "timeout": 30
+          },
+          {
+            "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/dart_format.sh",
             "timeout": 30
           }

--- a/plugins/wingspan/hooks/scripts/dart_analyze.sh
+++ b/plugins/wingspan/hooks/scripts/dart_analyze.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+# Read the hook payload from stdin
+input=$(cat)
+
+# Check jq availability
+if ! command -v jq &>/dev/null; then
+  echo "dart_analyze hook: jq not found, skipping" >&2
+  exit 0
+fi
+
+# Extract file path from the tool input
+file_path=$(jq -r '.tool_input.file_path // empty' <<< "$input")
+
+# Skip if no file path or not a Dart file
+if [[ -z "$file_path" || "$file_path" != *.dart ]]; then
+  exit 0
+fi
+
+# Run dart analyze on the single file
+output=$(dart analyze "$file_path" 2>&1) || {
+  echo "$output" >&2
+  exit 2
+}


### PR DESCRIPTION
## Description

Adds a `PostToolUse` hook that runs `dart analyze` on `.dart` files after `Edit` or `Write` tool calls. When analysis finds errors, the output is surfaced to Claude so it can fix them immediately.

This establishes the hooks infrastructure for the plugin (`hooks/hooks.json` + `hooks/scripts/`).

Closes #47

## Type of Change

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)