### PR TITLE
feat: add dart format post-edit hook

### DIFF
--- a/plugins/wingspan/hooks/hooks.json
+++ b/plugins/wingspan/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Wingspan post-edit hooks for Dart/Flutter development",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/dart_format.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/wingspan/hooks/scripts/dart_format.sh
+++ b/plugins/wingspan/hooks/scripts/dart_format.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+# Read the hook payload from stdin
+input=$(cat)
+
+# Check jq availability
+if ! command -v jq &>/dev/null; then
+  echo "dart_format hook: jq not found, skipping" >&2
+  exit 0
+fi
+
+# Extract file path from the tool input
+file_path=$(jq -r '.tool_input.file_path // empty' <<< "$input")
+
+# Skip if no file path or not a Dart file
+if [[ -z "$file_path" || "$file_path" != *.dart ]]; then
+  exit 0
+fi
+
+# Run dart format on the single file (auto-fix, always exit 0)
+dart format "$file_path" &>/dev/null || true


### PR DESCRIPTION
## Description

Add a Claude Code hook that automatically runs `dart format` on Dart files after they are edited. The hook triggers on `PostToolUse` for `Edit` and `Write` tools, checks if the touched file ends in `.dart`, and runs `dart format <file>` to auto-fix formatting.

Closes #46

## Type of Change

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)