### PR TITLE
feat: Clear Context and X

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ The plugin supports three phases:
 2. **`/plan`** — Transform brainstorm output into an actionable implementation plan. Includes codebase review, optional external research, and flow analysis.
 3. **`/build`** — Execute implementation plans: write code and tests, run quality review, and ship a pull request.
 
+Each phase persists its output to `docs/` so the next phase can discover it from a cold start. When a skill offers a forward transition (e.g., brainstorm → plan), it must present **"Clear context and [next step]"** as the first handoff option. When selected, display the `/clear` command followed by the next skill's invocation, then stop. This gives the model a fresh context window without losing work.
+
 Supporting skills:
 
 - `/create-branch` (workspace setup)

--- a/plugins/wingspan/skills/brainstorm/SKILL.md
+++ b/plugins/wingspan/skills/brainstorm/SKILL.md
@@ -155,7 +155,7 @@ Use **AskUserQuestion tool** to consider next steps:
 
 **If the user selects "Clear context and plan"** → output the following and then stop:
 
-```
+```md
 To continue with a fresh context, run:
 
 /clear

--- a/plugins/wingspan/skills/brainstorm/SKILL.md
+++ b/plugins/wingspan/skills/brainstorm/SKILL.md
@@ -148,16 +148,32 @@ Use **AskUserQuestion tool** to consider next steps:
 **Question**: "Brainstorm complete! What would you like to do next?"
 
 **Options:**
-1. **Review and refine approach:** improve the document using structured review
+1. **Clear context and plan**: clear context for a fresh start, then plan
 2. **Continue with planning**: run the `/plan` skill to create a detailed implementation plan
-3. **Done for now**: brainstorm complete. To start planning later: `/plan`
+3. **Review and refine approach:** improve the document using structured review
+4. **Done for now**: brainstorm complete. To start planning later: `/plan`
+
+**If the user selects "Clear context and plan"** → output the following and then stop:
+
+```
+To continue with a fresh context, run:
+
+/clear
+
+Then start planning with:
+
+/plan
+```
 
 **If the user selects "Review and refine approach"** then apply the @refine-approach skill to the document.
 
 When `refine-approach` is complete, present these options:
 
-1. **Move to planning**: run the `/plan` skill to create a detailed implementation plan
-2. **Done for now**: ideation complete. To start planning later: `/plan`
+1. **Clear context and plan**: clear context for a fresh start, then plan
+2. **Move to planning**: run the `/plan` skill to create a detailed implementation plan
+3. **Done for now**: ideation complete. To start planning later: `/plan`
+
+**If the user selects "Clear context and plan"** → output the same instructions as above and then stop.
 
 ## Output Summary
 

--- a/plugins/wingspan/skills/plan/SKILL.md
+++ b/plugins/wingspan/skills/plan/SKILL.md
@@ -250,7 +250,7 @@ After writing the plan file, use the **AskUserQuestion tool** and present the fo
 Based on selection:
 
 - **Clear context and build** → Output the following (substituting the actual plan file path) and then stop:
-  ```
+  ```md
   To continue with a fresh context, run:
 
   /clear

--- a/plugins/wingspan/skills/plan/SKILL.md
+++ b/plugins/wingspan/skills/plan/SKILL.md
@@ -241,17 +241,28 @@ After writing the plan file, use the **AskUserQuestion tool** and present the fo
 
 **Options:**
 
-1. **Open the plan file in my code editor**: open the plan file for review
-2. **Run `/plan-technical-review` on this plan**: run the technical review skill to validate the plan
-3. **Review and refine**: improve the plan through self-review
-4. **Start building**: execute this plan with `/build`
+1. **Clear context and build**: clear context for a fresh start, then build
+2. **Start building**: execute this plan with `/build`
+3. **Open the plan file in my code editor**: open the plan file for review
+4. **Run `/plan-technical-review` on this plan**: run the technical review skill to validate the plan
+5. **Review and refine**: improve the plan through self-review
 
 Based on selection:
 
+- **Clear context and build** → Output the following (substituting the actual plan file path) and then stop:
+  ```
+  To continue with a fresh context, run:
+
+  /clear
+
+  Then start building with:
+
+  /build docs/plan/<actual-plan-filename>.md
+  ```
+- **Start building** → Call the `/build` skill with the plan file path
 - **Open plan in editor** → Run `open docs/plan/<plan_filename>.md` to open the file in the user's default editor
 - **`/plan-technical-review`** → Call the `/plan-technical-review` skill with the plan file path
 - **Review and refine** → Load `refine-approach` skill.
-- **Start building** → Call the `/build` skill with the plan file path
 - **Other** (automatically provided) → Accept free text for rework or specific changes
 
 ## Important

--- a/plugins/wingspan/skills/plan/SKILL.md
+++ b/plugins/wingspan/skills/plan/SKILL.md
@@ -250,6 +250,7 @@ After writing the plan file, use the **AskUserQuestion tool** and present the fo
 Based on selection:
 
 - **Clear context and build** → Output the following (substituting the actual plan file path) and then stop:
+
   ```md
   To continue with a fresh context, run:
 
@@ -259,6 +260,7 @@ Based on selection:
 
   /build docs/plan/<actual-plan-filename>.md
   ```
+
 - **Start building** → Call the `/build` skill with the plan file path
 - **Open plan in editor** → Run `open docs/plan/<plan_filename>.md` to open the file in the user's default editor
 - **`/plan-technical-review`** → Call the `/plan-technical-review` skill with the plan file path


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description

Closes #40 

Notice that the `/build` phase, as it is right now, it is a terminal step. When we introduce `/review` and/or `/learn`, `build` should be updated as well

## Type of Change

<!--- Check the one that applies to this PR. -->

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
