### PR TITLE
feat: marked skills whether they can be triggered by the user or not and allow to clear context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,9 @@ The plugin supports three phases:
 2. **`/plan`** — Transform brainstorm output into an actionable implementation plan. Includes codebase review, optional external research, and flow analysis.
 3. **`/build`** — Execute implementation plans: write code and tests, run quality review, and ship a pull request.
 
-Each phase persists its output to `docs/` so the next phase can discover it from a cold start. When a skill offers a forward transition (e.g., brainstorm → plan), it must present **"Clear context and [next step]"** as the first handoff option. When selected, display the `/clear` command followed by the next skill's invocation, then stop. This gives the model a fresh context window without losing work.
+Each phase persists its output to `docs/` so the next phase can discover it from a cold start.
+
+**Clear context handoff:** User-invocable skills (`user-invocable: true`) that have a forward transition (e.g., brainstorm → plan) must present **"Clear context and [next step]"** as the first handoff option. When selected, display the `/clear` command followed by the next skill's invocation, then stop. This gives the model a fresh context window without losing work. Skills invoked by other skills must not offer this — they return control to the caller instead.
 
 Supporting skills:
 

--- a/plugins/wingspan/skills/brainstorm/SKILL.md
+++ b/plugins/wingspan/skills/brainstorm/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: brainstorm
+user-invocable: true
 description: Explore requirements and approaches through collaborative dialogue before planning implementation
 argument-hint: feature or idea to explore
 ---

--- a/plugins/wingspan/skills/build/SKILL.md
+++ b/plugins/wingspan/skills/build/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: build
+user-invocable: true
 description: Execute an implementation plan — write code and tests and run quality review, and ship a pull request following VGV conventions.
 argument-hint: plan file path
 ---

--- a/plugins/wingspan/skills/create-branch/SKILL.md
+++ b/plugins/wingspan/skills/create-branch/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: create-branch
+user-invocable: true
 description: Set up a workspace (branch or worktree) before writing artifacts
 ---
 

--- a/plugins/wingspan/skills/elements-of-style/SKILL.md
+++ b/plugins/wingspan/skills/elements-of-style/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: elements-of-style
+user-invocable: false
 description: Apply Strunk's Elements of Style principles when writing or editing prose. Use when creating documents, editing text, reviewing writing, drafting emails, or any task requiring clear, vigorous English. Triggers on requests to "write clearly," "edit for style," "improve writing," or produce professional prose.
 ---
 

--- a/plugins/wingspan/skills/plan-technical-review/SKILL.md
+++ b/plugins/wingspan/skills/plan-technical-review/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: plan-technical-review
+user-invocable: true
 description: Conducts a comprehensive technical review of the plan, ensuring it meets requirements, follows best practices, and is ready for implementation.
 ---
 
@@ -25,3 +26,30 @@ After all agents complete, if the plan-splitting-agent recommends a split:
    - Add a note at the top of the original plan file: ``> **Note:** This plan has been split into parts. See the `-part-N` files in this directory.``
 
 If the plan-splitting-agent reports no split needed: include the scope summary in the review output, no further action.
+
+## Handoff
+
+**When invoked directly by the user**, use **AskUserQuestion** to present next steps after the review is complete:
+
+**Question**: "Technical review complete! What would you like to do next?"
+
+**Options:**
+
+1. **Clear context and build**: clear context for a fresh start, then build
+2. **Start building**: execute the plan with `/build`
+3. **Refine the plan**: improve the plan based on review findings
+4. **Done for now**: review complete
+
+**If the user selects "Clear context and build"** → output the following (substituting the actual plan file path) and then stop:
+
+```md
+To continue with a fresh context, run:
+
+/clear
+
+Then start building with:
+
+/build docs/plan/<actual-plan-filename>.md
+```
+
+**When invoked by another skill** (e.g., from `/plan`), return control to the caller after the review completes — do not present handoff options.

--- a/plugins/wingspan/skills/plan/SKILL.md
+++ b/plugins/wingspan/skills/plan/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: plan
+user-invocable: true
 description: Turn high-level brainstorming and ideas into well-structured, actionable plans for implementation that follow VGV conventions and patterns.
 argument-hint: feature, bug fix, or improvement to plan
 ---

--- a/plugins/wingspan/skills/refine-approach/SKILL.md
+++ b/plugins/wingspan/skills/refine-approach/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: refine-approach
+user-invocable: true
 description: This skill should be used to review and refine proposed brainstorms and planning documents before proceeding to implementation. It identifies gaps, clarifies assumptions, and ensures the approach is well thought out.
 ---
 
@@ -71,14 +72,52 @@ Simplification is purposeful removal of unnecessary complexity, not shortening f
 
 After changes are complete, ask:
 
-1. **Refine again** - Another review pass
-2. **Review complete** - Document is ready
+1. **Refine again** — another review pass
+2. **Review complete** — document is ready
+
+**When invoked directly by the user** (not as part of another skill), also determine the document type and offer clear context handoff as the first option:
+
+**If the document is a brainstorm** (from `docs/brainstorm/`):
+
+1. **Clear context and plan**: clear context for a fresh start, then plan
+2. **Refine again** — another review pass
+3. **Done for now** — document is ready
+
+**If the document is a plan** (from `docs/plan/`):
+
+1. **Clear context and build**: clear context for a fresh start, then build
+2. **Refine again** — another review pass
+3. **Done for now** — document is ready
+
+**If the user selects "Clear context and plan"** → output the following and then stop:
+
+```md
+To continue with a fresh context, run:
+
+/clear
+
+Then start planning with:
+
+/plan
+```
+
+**If the user selects "Clear context and build"** → output the following (substituting the actual plan file path) and then stop:
+
+```md
+To continue with a fresh context, run:
+
+/clear
+
+Then start building with:
+
+/build docs/plan/<actual-plan-filename>.md
+```
+
+**When invoked by another skill** (e.g., from `/brainstorm` or `/plan`), only offer "Refine again" and "Review complete", then return control to the caller.
 
 ### Iteration guidance
 
 After 2 refinement passes, recommend completion—diminishing returns are likely. But if the user wants to continue, allow it.
-
-Return control to the caller (workflow or user) after selection.
 
 ## What NOT to Do
 


### PR DESCRIPTION

<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description

<!--- Describe what changed and why. -->
Closes #74 
Added user-invocable: true or false to each skill and the option to clear context to the only user-triggered skills
## Type of Change

<!--- Check the one that applies to this PR. -->

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
