### PR TITLE
fix: add trigger phrases to skill descriptions

### DIFF
--- a/plugins/wingspan/skills/brainstorm/SKILL.md
+++ b/plugins/wingspan/skills/brainstorm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: brainstorm
 user-invocable: true
-description: Explore requirements and approaches through collaborative dialogue before planning implementation
+description: Explore requirements and approaches through collaborative dialogue before planning implementation. Use when user says "brainstorm", "explore idea", "what should we build", "think through this", or "let's discuss approaches".
 argument-hint: feature or idea to explore
 ---
 

--- a/plugins/wingspan/skills/build/SKILL.md
+++ b/plugins/wingspan/skills/build/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: build
 user-invocable: true
-description: Execute an implementation plan — write code and tests and run quality review, and ship a pull request following VGV conventions.
+description: Execute an implementation plan — write code and tests, run quality review, and ship a pull request. Use when user says "build this", "implement the plan", "start coding", "execute the plan", or "ship it".
 argument-hint: plan file path
 ---
 

--- a/plugins/wingspan/skills/create-branch/SKILL.md
+++ b/plugins/wingspan/skills/create-branch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-branch
 user-invocable: true
-description: Set up a workspace (branch or worktree) before writing artifacts
+description: Set up a workspace branch or worktree before writing artifacts. Use when user says "create a branch", "set up workspace", "start a feature branch", or "new branch".
 ---
 
 # Create a working branch

--- a/plugins/wingspan/skills/create-branch/SKILL.md
+++ b/plugins/wingspan/skills/create-branch/SKILL.md
@@ -1,12 +1,8 @@
 ---
 name: create-branch
 user-invocable: true
-<<<<<<< fix/add-trigger-phrases-to-descriptions
 description: Set up a workspace branch or worktree before writing artifacts. Use when user says "create a branch", "set up workspace", "start a feature branch", or "new branch".
-=======
-description: Set up a workspace (branch or worktree) before writing artifacts
 argument-hint: feature name or context
->>>>>>> main
 ---
 
 # Create a working branch

--- a/plugins/wingspan/skills/plan-technical-review/SKILL.md
+++ b/plugins/wingspan/skills/plan-technical-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan-technical-review
 user-invocable: true
-description: Conducts a comprehensive technical review of the plan, ensuring it meets requirements, follows best practices, and is ready for implementation.
+description: Conduct a comprehensive technical review of an implementation plan, ensuring it meets requirements and follows best practices. Use when user says "review the plan", "is this plan ready", "validate my plan", or "check the plan".
 ---
 
 # Plan technical review

--- a/plugins/wingspan/skills/plan-technical-review/SKILL.md
+++ b/plugins/wingspan/skills/plan-technical-review/SKILL.md
@@ -1,12 +1,8 @@
 ---
 name: plan-technical-review
 user-invocable: true
-<<<<<<< fix/add-trigger-phrases-to-descriptions
 description: Conduct a comprehensive technical review of an implementation plan, ensuring it meets requirements and follows best practices. Use when user says "review the plan", "is this plan ready", "validate my plan", or "check the plan".
-=======
-description: Conducts a comprehensive technical review of the plan, ensuring it meets requirements, follows best practices, and is ready for implementation.
 argument-hint: path to plan file
->>>>>>> main
 ---
 
 # Plan technical review

--- a/plugins/wingspan/skills/plan/SKILL.md
+++ b/plugins/wingspan/skills/plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan
 user-invocable: true
-description: Turn high-level brainstorming and ideas into well-structured, actionable plans for implementation that follow VGV conventions and patterns.
+description: Turn high-level brainstorming and ideas into well-structured, actionable implementation plans. Use when user says "plan this", "create a plan", "how should we implement", or "write an implementation plan".
 argument-hint: feature, bug fix, or improvement to plan
 ---
 

--- a/plugins/wingspan/skills/refine-approach/SKILL.md
+++ b/plugins/wingspan/skills/refine-approach/SKILL.md
@@ -1,12 +1,8 @@
 ---
 name: refine-approach
 user-invocable: true
-<<<<<<< fix/add-trigger-phrases-to-descriptions
 description: Review and refine brainstorm or planning documents before implementation. Identifies gaps, clarifies assumptions, and ensures the approach is sound. Use when user says "refine this", "review my approach", "improve the document", or "is this ready".
-=======
-description: This skill should be used to review and refine proposed brainstorms and planning documents before proceeding to implementation. It identifies gaps, clarifies assumptions, and ensures the approach is well thought out.
 argument-hint: path to document to refine
->>>>>>> main
 ---
 
 # Refine Approach

--- a/plugins/wingspan/skills/refine-approach/SKILL.md
+++ b/plugins/wingspan/skills/refine-approach/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: refine-approach
 user-invocable: true
-description: This skill should be used to review and refine proposed brainstorms and planning documents before proceeding to implementation. It identifies gaps, clarifies assumptions, and ensures the approach is well thought out.
+description: Review and refine brainstorm or planning documents before implementation. Identifies gaps, clarifies assumptions, and ensures the approach is sound. Use when user says "refine this", "review my approach", "improve the document", or "is this ready".
 ---
 
 # Refine Approach


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Per the skills guide, descriptions should include both what the skill does and when to use it (trigger phrases users would say). Added trigger phrases to all 6 skill descriptions to improve auto-triggering.

## Type of Change

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)