### PR TITLE
fix: add missing argument-hint to 3 skills

### DIFF
--- a/plugins/wingspan/skills/create-branch/SKILL.md
+++ b/plugins/wingspan/skills/create-branch/SKILL.md
@@ -2,6 +2,7 @@
 name: create-branch
 user-invocable: true
 description: Set up a workspace (branch or worktree) before writing artifacts
+argument-hint: feature name or context
 ---
 
 # Create a working branch

--- a/plugins/wingspan/skills/plan-technical-review/SKILL.md
+++ b/plugins/wingspan/skills/plan-technical-review/SKILL.md
@@ -2,6 +2,7 @@
 name: plan-technical-review
 user-invocable: true
 description: Conducts a comprehensive technical review of the plan, ensuring it meets requirements, follows best practices, and is ready for implementation.
+argument-hint: path to plan file
 ---
 
 # Plan technical review

--- a/plugins/wingspan/skills/refine-approach/SKILL.md
+++ b/plugins/wingspan/skills/refine-approach/SKILL.md
@@ -2,6 +2,7 @@
 name: refine-approach
 user-invocable: true
 description: This skill should be used to review and refine proposed brainstorms and planning documents before proceeding to implementation. It identifies gaps, clarifies assumptions, and ensures the approach is well thought out.
+argument-hint: path to document to refine
 ---
 
 # Refine Approach


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

`create-branch`, `plan-technical-review`, and `refine-approach` were missing the `argument-hint` frontmatter field. Added hints so users see what argument to pass when invoking these skills.

## Type of Change

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)