### PR TITLE
chore: generalize flutter-specific language in tech-agnostic agents

### DIFF
--- a/agents/analysis/plan-splitting-agent.md
+++ b/agents/analysis/plan-splitting-agent.md
@@ -6,7 +6,7 @@ description: |
   <examples>
     <example>
       Context: Developer runs /plan-technical-review on a large feature plan.
-      user: "Review this plan for the new authentication flow — it touches API client, repository, Bloc, and three screens."
+      user: "Review this plan for the new authentication flow — it touches API client, repository, state management, and three screens."
       assistant: "I'll run the plan-splitting agent to assess whether this should be split across multiple PRs."
       <commentary>
         Plans spanning multiple layers (data, domain, presentation) with new packages are strong candidates for splitting.
@@ -22,7 +22,7 @@ description: |
     </example>
     <example>
       Context: Developer has a large but tightly coupled plan.
-      user: "Review this plan — it adds a single complex widget with its Bloc, repository, and API client, all interdependent."
+      user: "Review this plan — it adds a single complex component with its state management, repository, and API client, all interdependent."
       assistant: "I'll run the plan-splitting agent to check if this can be split, or if the coupling means it should stay as one PR."
       <commentary>
         Not all large plans can be split. The agent should recognize tight coupling and recommend keeping as a single PR with a scope warning rather than forcing an awkward split.

--- a/skills/create/SKILL.md
+++ b/skills/create/SKILL.md
@@ -14,10 +14,12 @@ Route project creation to the right companion plugin. Wingspan does not scaffold
 
 <description>$ARGUMENTS</description>
 
-**If the description above is empty**, use the **AskUserQuestion tool**:
+**If the description above is empty:**
 
-- **Question:** "What kind of project would you like to create?"
-- **Options:** "Flutter app", "Dart package", "Dart CLI", "Other"
+1. First, scan recommendation files (Step 1 below) to discover available project types.
+2. Then use **AskUserQuestion tool**:
+   - **Question:** "What kind of project would you like to create?"
+   - **Options:** Build the option list from the discovered companion plugins' descriptions, plus "Other" as the last option.
 
 DO NOT proceed until you have a project description.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description

<!--- Describe what changed and why. -->
Closes #95 

The codebase already follows multi-stack examples where natural: e.g., `vgv-review-agent.md:75` lists "Bloc/Cubit, Redux, Zustand, MobX". Most other files fully agnostic with "detect the project's tech stack" preambles. This hybrid approach seems well-suited: agnostic by default, multi-stack examples only where the guidance would otherwise be too vague.

## Type of Change

<!--- Check the one that applies to this PR. -->

- [ ] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [x] Chore (`chore`)
