### PR TITLE
fix: show pre-tool narration instruction to the user before Context7 tools usage

### DIFF
--- a/agents/research/best-practices-research-agent.md
+++ b/agents/research/best-practices-research-agent.md
@@ -53,6 +53,7 @@ Only after checking skills **and** verifying API availability, gather additional
 1. **Leverage External Sources**:
 
    - Search the project's referenced standards and documentation
+   - Before using Context7, tell the user which library you are looking up and why, e.g. "Fetching official docs for X via Context7 — you may see a permission prompt to allow the library ID lookup."
    - Use Context7 MCP to access official documentation from GitHub, framework docs, and library references
    - Search the web for recent articles, guides, and community discussions
    - Identify and analyze well-regarded open source projects that demonstrate the practices

--- a/agents/research/official-docs-research-agent.md
+++ b/agents/research/official-docs-research-agent.md
@@ -55,6 +55,7 @@ You are an expert that knows all the ins and outs of the official documentation 
    **Why this matters:** APIs and scopes can be deprecated without warning. Without this check, developers waste hours debugging errors against dead APIs. A few minutes of validation saves hours of debugging.
 
 3. **Documentation Collection**:
+   - Before using Context7, tell the user which library you are looking up and why, e.g. "Fetching official docs for X via Context7 — you may see a permission prompt to allow the library ID lookup."
    - Start with Context7 to fetch official documentation
    - If Context7 is unavailable or incomplete, use web search as fallback
    - Prioritize official sources over third-party tutorials


### PR DESCRIPTION
## Description

<!--- Describe what changed and why. -->

Closes #107 

The pre-tool narration instruction now appears right before the Context7 usage step in each agent.

## Type of Change

<!--- Check the one that applies to this PR. -->

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
