### PR TITLE
doc: updated marketplace and plugin installation doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ AI-assisted workflows that follow Very Good Ventures best practices and standard
 Inside Claude Code:
 
 ```bash
-/plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace
-/plugin install wingspan@very_good_claude_marketplace
+/plugin marketplace add VeryGoodOpenSource/wingspan
+/plugin install wingspan@wingspan-marketplace
 ```
 
 ## Getting Started


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description

<!--- Describe what changed and why. -->
Current installation steps documentation is wrong, it tells to install `very_good_claude_marketplace` but that's not the Wingspan marketplace. Then, trying to install Wingspan plugin from that marketplace will fail

<img width="1080" height="279" alt="Screenshot 2026-04-07 at 08 43 17" src="https://github.com/user-attachments/assets/df1e9270-2695-47bf-81f9-bc859ef04476" />

Rollback to correct marketplace and plugin installation doc

<img width="653" height="165" alt="Screenshot 2026-04-07 at 08 45 40" src="https://github.com/user-attachments/assets/b80727dd-9cbb-4963-ab82-faa2792f0dec" />


## Type of Change

<!--- Check the one that applies to this PR. -->

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [x] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
