### PR TITLE
fix: prevent duplicate "Other" / "Something else" options in brainstorm

### DIFF
--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -94,7 +94,7 @@ Focus on: similar features, established patterns, CLAUDE.md guidance.
 
 #### 1.2. Collaborative conversation
 
-Use the **AskUserQuestion tool** to ask questions one at a time.
+Use the **AskUserQuestion tool** to ask questions one at a time. The tool automatically provides an "Other" option for free-text input — never add your own catch-all option (e.g., "Something else", "None of the above").
 
 **Question Techniques:**
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Closes #116.

AskUserQuestion auto-provides an "Other" option for free-text input. Without explicit guidance, the model added its own catch-all (e.g. "Something else"), creating two near-identical choices.

## Type of Change

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)