### PR TITLE
fix: include brainstorm doc path in clear context handoffs (#119)

### DIFF
--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -177,7 +177,7 @@ Use **AskUserQuestion tool** to consider next steps:
 3. **Review and refine approach:** improve the document using structured review
 4. **Done for now**: brainstorm complete. To start planning later: `/plan`
 
-**If the user selects "Clear context and plan"** → output the following and then stop:
+**If the user selects "Clear context and plan"** → output the following (substituting the actual brainstorm doc path) and then stop:
 
 ```md
 To continue with a fresh context, run:
@@ -186,7 +186,7 @@ To continue with a fresh context, run:
 
 Then start planning with:
 
-/plan
+/plan docs/brainstorm/<actual-brainstorm-filename>.md
 ```
 
 **If the user selects "Review and refine approach"** then apply the @refine-approach skill to the document.

--- a/skills/refine-approach/SKILL.md
+++ b/skills/refine-approach/SKILL.md
@@ -91,7 +91,7 @@ After changes are complete, ask:
 2. **Refine again** — another review pass
 3. **Done for now** — document is ready
 
-**If the user selects "Clear context and plan"** → output the following and then stop:
+**If the user selects "Clear context and plan"** → output the following (substituting the actual brainstorm doc path) and then stop:
 
 ```md
 To continue with a fresh context, run:
@@ -100,7 +100,7 @@ To continue with a fresh context, run:
 
 Then start planning with:
 
-/plan
+/plan docs/brainstorm/<actual-brainstorm-filename>.md
 ```
 
 **If the user selects "Clear context and build"** → output the following (substituting the actual plan file path) and then stop:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Closes #119.

brainstorm and refine-approach now substitute the actual brainstorm file path into the `/plan` command when suggesting "Clear context and plan", matching the pattern already used for `/build` handoffs.

## Type of Change

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)