### PR TITLE
feat: optimize model and effort settings across agents and skills

### DIFF
--- a/agents/analysis/plan-splitting-agent.md
+++ b/agents/analysis/plan-splitting-agent.md
@@ -29,7 +29,8 @@ description: |
       </commentary>
     </example>
   </examples>
-model: inherit
+model: sonnet
+effort: medium
 ---
 
 # Plan Splitting Agent

--- a/agents/analysis/user-flow-analysis-agent.md
+++ b/agents/analysis/user-flow-analysis-agent.md
@@ -1,6 +1,7 @@
 ---
 name: user-flow-analysis-agent
 description: Analyzes specifications and feature descriptions for user flow completeness and gap identification. Use when a spec, plan, or feature description needs flow analysis, edge case discovery, or requirements validation.
+model: inherit
 ---
 
 # User flow analysis agent

--- a/agents/codebase-review/code-simplicity-review-agent.md
+++ b/agents/codebase-review/code-simplicity-review-agent.md
@@ -1,7 +1,8 @@
 ---
 name: code-simplicity-review-agent
 description: Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities.
-model: inherit
+model: sonnet
+effort: medium
 ---
 
 # Code simplicity review agent

--- a/agents/codebase-review/codebase-review-agent.md
+++ b/agents/codebase-review/codebase-review-agent.md
@@ -29,6 +29,8 @@ description: |
       </commentary>
     </example>
   </examples>
+model: sonnet
+effort: medium
 ---
 
 # Codebase Review Agent

--- a/agents/quality-review/pr-readiness-review-agent.md
+++ b/agents/quality-review/pr-readiness-review-agent.md
@@ -1,7 +1,7 @@
 ---
 name: pr-readiness-review-agent
 description: Checks PR readiness — formatting, static analysis, debug artifacts, and commit hygiene — to catch mechanical issues before opening a pull request.
-model: sonnet
+model: haiku
 effort: low
 ---
 

--- a/agents/quality-review/pr-readiness-review-agent.md
+++ b/agents/quality-review/pr-readiness-review-agent.md
@@ -1,7 +1,8 @@
 ---
 name: pr-readiness-review-agent
 description: Checks PR readiness — formatting, static analysis, debug artifacts, and commit hygiene — to catch mechanical issues before opening a pull request.
-model: inherit
+model: sonnet
+effort: low
 ---
 
 # PR Readiness Review Agent

--- a/agents/quality-review/test-quality-review-agent.md
+++ b/agents/quality-review/test-quality-review-agent.md
@@ -29,7 +29,7 @@ description: |
       </commentary>
     </example>
   </examples>
-model: inherit
+model: sonnet
 ---
 
 # Test Quality Review Agent

--- a/agents/research/best-practices-research-agent.md
+++ b/agents/research/best-practices-research-agent.md
@@ -1,7 +1,7 @@
 ---
 name: best-practices-research-agent
 description: Researches and synthesizes best practices for the project's technology stack, following first VGV conventions and the project's CLAUDE.md, then official language and framework documentation, and finally other industry standards.
-model: inherit
+model: sonnet
 ---
 
 # Best practices research agent

--- a/agents/research/official-docs-research-agent.md
+++ b/agents/research/official-docs-research-agent.md
@@ -1,7 +1,7 @@
 ---
 name: official-docs-research-agent
 description: Gathers comprehensive documentation and best practices for frameworks, libraries, or dependencies. Use when you need official docs, version-specific constraints, or implementation patterns.
-model: inherit
+model: sonnet
 ---
 
 # Official docs research agent

--- a/skills/create-branch/SKILL.md
+++ b/skills/create-branch/SKILL.md
@@ -3,6 +3,7 @@ name: create-branch
 user-invocable: true
 description: Sets up a workspace branch or worktree before writing artifacts. Use when user says "create a branch", "set up workspace", "start a feature branch", or "new branch".
 argument-hint: feature name or context
+effort: low
 compatibility: Designed for Claude Code (or similar products with agent support)
 ---
 

--- a/skills/create/SKILL.md
+++ b/skills/create/SKILL.md
@@ -3,6 +3,7 @@ name: create
 user-invocable: true
 description: Scaffolds a new project by routing to the right companion plugin's create skill. Use when user says "create a project", "new flutter app", "start a dart package", "scaffold", or asks to set up a new codebase.
 argument-hint: what to create (e.g., "flutter app", "dart package")
+effort: low
 allowed-tools: Read, Glob, Skill
 compatibility: Designed for Claude Code (or similar products with agent support)
 ---

--- a/skills/debrief/SKILL.md
+++ b/skills/debrief/SKILL.md
@@ -3,6 +3,7 @@ name: debrief
 user-invocable: true
 description: Produces a structured post-incident analysis — timeline, root cause, and actionable follow-ups — while context is fresh. Use when user says "debrief", "post-mortem", "incident review", or "root cause analysis".
 argument-hint: incident description, PR/commit refs, or error context
+effort: high
 compatibility: Designed for Claude Code (or similar products with agent support)
 ---
 

--- a/skills/plan-technical-review/SKILL.md
+++ b/skills/plan-technical-review/SKILL.md
@@ -3,6 +3,7 @@ name: plan-technical-review
 user-invocable: true
 description: Conducts a comprehensive technical review of an implementation plan, ensuring it meets requirements and follows best practices. Use when user says "review the plan", "is this plan ready", "validate my plan", or "check the plan".
 argument-hint: path to plan file
+effort: high
 compatibility: Designed for Claude Code (or similar products with agent support)
 ---
 

--- a/skills/rebase/SKILL.md
+++ b/skills/rebase/SKILL.md
@@ -3,6 +3,7 @@ name: rebase
 user-invocable: true
 disable-model-invocation: true
 description: Rebases the current feature branch onto the base branch (main/master/develop). Use when user says "rebase", "sync branch", or "update branch".
+effort: low
 compatibility: Designed for Claude Code (or similar products with git access)
 ---
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -3,6 +3,7 @@ name: review
 user-invocable: true
 description: Runs quality review agents on demand — reviews code, assesses quality, and identifies issues before merging. Use when user says "review this code", "review my code", "code review", "review", "check this code", or "review before merging".
 argument-hint: "[path/to/files/or/directories (optional)]"
+effort: high
 compatibility: Designed for Claude Code (or similar products with agent support)
 ---
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Closes #115.

Route 7 agents to Sonnet instead of inheriting Opus for tasks that don't need deep reasoning (research, mechanical reviews, pattern matching). Keep inherit for `vgv-review` and `architecture-review` where nuanced judgment matters. Add effort levels matching task complexity — low for mechanical ops, high for reviews.

## Type of Change

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)