### PR TITLE
fix(skills): use space-separated allowed-tools format

### DIFF
--- a/skills/create/SKILL.md
+++ b/skills/create/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: true
 description: Scaffolds a new project by routing to the right companion plugin's create skill. Use when user says "create a project", "new flutter app", "start a dart package", "scaffold", or asks to set up a new codebase.
 argument-hint: what to create (e.g., "flutter app", "dart package")
 effort: low
-allowed-tools: Read, Glob, Skill
+allowed-tools: Read Glob Skill
 compatibility: Designed for Claude Code (or similar products with agent support)
 ---
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Docs require space-separated strings or YAML lists for `allowed-tools`, not comma-separated values.

## Type of Change

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)