### PR TITLE
docs: fix missing backtick in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Start here. Describe the problem or idea — the bigger and more open-ended, the
 
 Providing context up front produces much better results than invoking `/brainstorm` on its own. This opens a collaborative dialogue to explore requirements, constraints, and approaches. The output is saved to `docs/brainstorm/` so the next phase can pick it up.
 
-### 2. `/plan/
+### 2. `/plan`
 
 Once you're happy with the brainstorm, turn it into an actionable implementation plan:
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description

Fixes a missing backtick in the README

## Type of Change

<!--- Check the one that applies to this PR. -->


- [x] Documentation (`docs`)
