### PR TITLE
feat: extracted shared review consolidation to reference

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -152,21 +152,7 @@ The 5 agents and their report filenames:
 
 ### After all reviews complete
 
-1. **Consolidate findings** from all summaries into three categories:
-   - **Critical** (must fix before merge): Bugs, missing tests, layer violations, broken analysis
-   - **Important** (should fix): Convention deviations, test gaps, naming issues
-   - **Suggestions** (note for PR): Style improvements, minor simplifications
-
-2. **Auto-fix minor issues**: formatting (run the project's formatter), lint warnings. Stage and commit fixes.
-
-3. **Fix critical issues**: Read the specific report file (e.g., `docs/reviews/architecture-review.md`) for full details on each critical finding. Address each one, re-run validation (project's linter and test runner), and commit. Only read reports that contain critical issues — do not load all 5 reports into context.
-
-4. **Present important issues** to the user via **AskUserQuestion**:
-   - **Fix all**: address every important issue (read relevant report files for details)
-   - **Review the list first**: show the full list for the user to decide
-   - **Skip to shipping**: note them in the PR description instead
-
-5. **Record suggestions** for inclusion in the PR description.
+Follow the [review consolidation procedure](../shared/references/review-consolidation.md): categorize findings, auto-fix minor issues, fix critical issues, present important issues to the user, and record suggestions.
 
 ## Phase 4 — Ship
 

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -152,7 +152,7 @@ The 5 agents and their report filenames:
 
 ### After all reviews complete
 
-Follow the [review consolidation procedure](../shared/references/review-consolidation.md): categorize findings, auto-fix minor issues, fix critical issues, present important issues to the user, and record suggestions.
+Follow the [review consolidation procedure](references/review-consolidation.md): categorize findings, auto-fix minor issues, fix critical issues, present important issues to the user, and record suggestions.
 
 ## Phase 4 — Ship
 

--- a/skills/build/references/review-consolidation.md
+++ b/skills/build/references/review-consolidation.md
@@ -1,0 +1,1 @@
+../../shared/references/review-consolidation.md

--- a/skills/hotfix/SKILL.md
+++ b/skills/hotfix/SKILL.md
@@ -133,13 +133,7 @@ The 2 agents and their report filenames:
 
 ### After reviews complete
 
-1. **Critical findings** → Read the specific report file (e.g., `docs/hotfix-review/vgv-review.md`) for full details on each critical finding. Fix immediately, re-run validation, and commit. Only read reports that contain critical issues — do not load both reports into context unnecessarily.
-
-2. **Important findings** → use **AskUserQuestion**:
-   - **Fix all**: address every important issue (read relevant report files for details)
-   - **Skip to shipping**: note them in the PR description
-
-3. **Suggestions** → record for PR description.
+Follow the [review consolidation procedure](../shared/references/review-consolidation.md): fix critical issues, present important issues to the user, and record suggestions.
 
 ### Cleanup
 

--- a/skills/hotfix/SKILL.md
+++ b/skills/hotfix/SKILL.md
@@ -133,7 +133,7 @@ The 2 agents and their report filenames:
 
 ### After reviews complete
 
-Follow the [review consolidation procedure](../shared/references/review-consolidation.md): fix critical issues, present important issues to the user, and record suggestions.
+Follow the [review consolidation procedure](references/review-consolidation.md): fix critical issues, present important issues to the user, and record suggestions.
 
 ### Cleanup
 

--- a/skills/hotfix/references/review-consolidation.md
+++ b/skills/hotfix/references/review-consolidation.md
@@ -1,0 +1,1 @@
+../../shared/references/review-consolidation.md

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -97,7 +97,7 @@ Default agents and their report filenames:
 
 After all reviews complete:
 
-1. [Categorize findings](../shared/references/review-consolidation.md) from all summaries into Critical, Important, and Suggestions.
+1. [Categorize findings](references/review-consolidation.md) from all summaries into Critical, Important, and Suggestions.
 
 2. **Present the consolidated summary** to the user with counts per category and the one-line descriptions from each agent.
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -97,10 +97,7 @@ Default agents and their report filenames:
 
 After all reviews complete:
 
-1. **Consolidate findings** from all summaries into three categories:
-   - **Critical** (must fix before merge): Bugs, missing tests, layer violations, broken analysis
-   - **Important** (should fix): Convention deviations, test gaps, naming issues
-   - **Suggestions** (nice to have): Style improvements, minor simplifications
+1. [Categorize findings](../shared/references/review-consolidation.md) from all summaries into Critical, Important, and Suggestions.
 
 2. **Present the consolidated summary** to the user with counts per category and the one-line descriptions from each agent.
 

--- a/skills/review/references/review-consolidation.md
+++ b/skills/review/references/review-consolidation.md
@@ -1,0 +1,1 @@
+../../shared/references/review-consolidation.md

--- a/skills/shared/references/review-consolidation.md
+++ b/skills/shared/references/review-consolidation.md
@@ -1,0 +1,22 @@
+# Review Consolidation
+
+## Categorize findings
+
+Consolidate findings from all agent summaries into three categories:
+
+- **Critical** (must fix before merge): Bugs, missing tests, layer violations, broken analysis
+- **Important** (should fix): Convention deviations, test gaps, naming issues
+- **Suggestions** (note for PR): Style improvements, minor simplifications
+
+## Fix and triage
+
+1. **Auto-fix minor issues**: formatting (run the project's formatter), lint warnings. Stage and commit fixes.
+
+2. **Fix critical issues**: Read the specific report file for full details on each critical finding. Address each one, re-run validation (project's linter and test runner), and commit. Only read reports that contain critical issues — do not load all reports into context.
+
+3. **Present important issues** to the user via **AskUserQuestion**:
+   - **Fix all**: address every important issue (read relevant report files for details)
+   - **Review the list first**: show the full list for the user to decide
+   - **Skip to shipping**: note them in the PR description instead
+
+4. **Record suggestions** for inclusion in the PR description.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description

<!--- Describe what changed and why. -->
#145 

The "consolidate findings into Critical / Important / Suggestions" block appears in:

build/SKILL.md Phase 3 (lines 155-169) — 15 lines
hotfix/SKILL.md Phase 4 (lines 136-143) — 8 lines
review/SKILL.md Step 3 (lines 99-107) — 9 lines
Fix: Extract to a shared reference references/review-consolidation.md. Saves ~150 words.

## Type of Change

<!--- Check the one that applies to this PR. -->

- [ ] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [x] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
