### PR TITLE
feat: moved branch scope detection to scripts

### DIFF
--- a/skills/create-branch/SKILL.md
+++ b/skills/create-branch/SKILL.md
@@ -25,9 +25,15 @@ Run:
 git rev-parse --abbrev-ref HEAD
 ```
 
-**If the result is NOT `main`, `master`, or `develop`:** the session is already on a feature branch. Skip silently — return control to the caller without any output.
+Compare the result against the base branch detected by:
 
-**If the result is `main`, `master`, or `develop` (or `HEAD` for detached state):** proceed to Step 2.
+```!
+bash scripts/detect-base-branch.sh
+```
+
+**If the current branch is NOT the base branch (and not `HEAD`):** the session is already on a feature branch. Skip silently — return control to the caller without any output.
+
+**If the current branch IS the base branch (or `HEAD` for detached state):** proceed to Step 2.
 
 ## Step 2: Infer branch name
 

--- a/skills/create-branch/scripts/detect-base-branch.sh
+++ b/skills/create-branch/scripts/detect-base-branch.sh
@@ -1,0 +1,1 @@
+../../shared/scripts/detect-base-branch.sh

--- a/skills/rebase/SKILL.md
+++ b/skills/rebase/SKILL.md
@@ -15,7 +15,7 @@ Rebase the current feature branch onto the latest base branch to keep it up-to-d
 
 Run these checks in order. If any fail, inform the user and stop.
 
-### Detect current branch
+### Detect current branch and base branch
 
 ```bash
 git rev-parse --abbrev-ref HEAD
@@ -23,9 +23,13 @@ git rev-parse --abbrev-ref HEAD
 
 If the result is `main`, `master`, or `develop` — inform the user they're already on the base branch and stop.
 
-### Detect base branch
+Detect the base branch:
 
-Check for `main`, `master`, `develop` (in that order). Use the first one that exists. If none exist, inform the user and stop.
+```!
+bash scripts/detect-base-branch.sh
+```
+
+If the script exits with an error, inform the user no base branch was found and stop.
 
 ### Check for uncommitted changes
 

--- a/skills/rebase/scripts/detect-base-branch.sh
+++ b/skills/rebase/scripts/detect-base-branch.sh
@@ -1,0 +1,1 @@
+../../shared/scripts/detect-base-branch.sh

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -27,32 +27,16 @@ Parse the review scope above for optional file paths or directories.
 
 **If no paths provided:**
 
-1. Detect current branch:
+Run the scope detection script:
 
-   ```bash
-   git rev-parse --abbrev-ref HEAD
-   ```
+```!
+bash scripts/detect-review-scope.sh
+```
 
-2. Detect default branch:
-
-   ```bash
-   git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'
-   ```
-
-   Fallback: check for `main`, then `master`.
-
-3. **If on a feature branch** (current branch differs from the default branch):
-   - Get changed files: `git diff <default-branch>...HEAD --name-only`
-   - Include uncommitted changes: `git diff --name-only` and `git diff --cached --name-only`
-   - Deduplicate the combined file list
-   - Announce scope summary: number of changed files, which areas of the codebase are affected
-   - Proceed to Step 2 — the user invoked `/review`, intent is clear
-
-4. **If on the default branch:**
-   - Tell the user: "You're on `<branch>`. No branch diff available."
-   - Use **AskUserQuestion**: "What would you like to review?" with options:
-     - **Specify files or directories**: accept paths from the user
-     - **Review entire project**: no scope constraint
+- **If `SCOPE=branch`**: use the listed files as review scope. Announce scope summary: number of changed files, which areas of the codebase are affected. Proceed to Step 2.
+- **If `SCOPE=default`**: tell the user: "You're on `<CURRENT_BRANCH>`. No branch diff available." Use **AskUserQuestion**: "What would you like to review?" with options:
+  - **Specify files or directories**: accept paths from the user
+  - **Review entire project**: no scope constraint
 
 ## Step 2 — Run Reviews
 

--- a/skills/review/scripts/detect-review-scope.sh
+++ b/skills/review/scripts/detect-review-scope.sh
@@ -1,0 +1,1 @@
+../../shared/scripts/detect-review-scope.sh

--- a/skills/shared/scripts/detect-base-branch.sh
+++ b/skills/shared/scripts/detect-base-branch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Detect the default/base branch of the repository.
+# Checks main, master, develop in order. Outputs the first one found.
+# Exits 1 if none exist.
+
+for branch in main master develop; do
+  if git rev-parse --verify "$branch" &>/dev/null ||
+     git rev-parse --verify "origin/$branch" &>/dev/null; then
+    echo "$branch"
+    exit 0
+  fi
+done
+
+echo "ERROR: no base branch found (checked main, master, develop)" >&2
+exit 1

--- a/skills/shared/scripts/detect-review-scope.sh
+++ b/skills/shared/scripts/detect-review-scope.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Detect review scope: current branch, base branch, and changed files.
+# Output format (one section per line):
+#   CURRENT_BRANCH=<branch>
+#   BASE_BRANCH=<branch>
+#   SCOPE=branch|default
+#   FILES (one per line after the FILES header)
+#
+# Usage: detect-review-scope.sh
+
+set -euo pipefail
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+echo "CURRENT_BRANCH=$CURRENT_BRANCH"
+
+# Detect base branch
+BASE_BRANCH=""
+DEFAULT_REF=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || true)
+if [ -n "$DEFAULT_REF" ]; then
+  BASE_BRANCH="$DEFAULT_REF"
+else
+  for branch in main master develop; do
+    if git rev-parse --verify "$branch" &>/dev/null ||
+       git rev-parse --verify "origin/$branch" &>/dev/null; then
+      BASE_BRANCH="$branch"
+      break
+    fi
+  done
+fi
+echo "BASE_BRANCH=$BASE_BRANCH"
+
+# Determine scope
+if [ "$CURRENT_BRANCH" = "$BASE_BRANCH" ] || [ -z "$BASE_BRANCH" ]; then
+  echo "SCOPE=default"
+else
+  echo "SCOPE=branch"
+  echo "FILES"
+  # Combine branch diff + uncommitted + staged, deduplicate
+  {
+    git diff "$BASE_BRANCH"...HEAD --name-only 2>/dev/null
+    git diff --name-only 2>/dev/null
+    git diff --cached --name-only 2>/dev/null
+  } | sort -u
+fi


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description
#145 

Multiple skills contain inline bash commands for detecting the current branch and base branch. These are deterministic operations that don't need LLM reasoning.

  1. Detect base branch — checks for main, then master, then develop. Appears in:
    - rebase/SKILL.md (lines 26-28)
    - review/SKILL.md (lines 38-42)
    - create-branch/SKILL.md (line 29 — checks if current branch is one of these)
  2. Detect review scope — review/SKILL.md (lines 30-56) runs ~6 bash commands to detect branch, base branch, changed files, uncommitted changes, and deduplicates.

Plan:

  1. Create skills/shared/scripts/detect-base-branch.sh — outputs the default branch name, exits 1 if none found
  2. Create skills/shared/scripts/detect-review-scope.sh — outputs current branch, base branch, and deduplicated changed files
  3. Update rebase/SKILL.md — replace inline detection with script call
  4. Update review/SKILL.md — replace multi-step scope detection with script call
  5. Update create-branch/SKILL.md — replace inline base-branch list with script call
  6. Add symlinks in each skill's directory so paths stay local

Scripts encapsulate existing bash logic. Skills still own all decision-making.

<!--- Describe what changed and why. -->

## Type of Change

<!--- Check the one that applies to this PR. -->

- [ ] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [x] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
