### PR TITLE
feat: tight prose from skills to reduce token usage

### DIFF
--- a/config/cspell.json
+++ b/config/cspell.json
@@ -18,7 +18,8 @@
     "worktree",
     "pasteable",
     "pubspec",
-    "worktrees"
+    "worktrees",
+    "undiscussed"
   ],
   "flagWords": []
 }

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -22,66 +22,28 @@ DO NOT proceed until you have a description from the user.
 
 ### 0. Assess scope and workspace
 
-Before diving into questions, determine whether this is a **new project** or a **feature for the current project**.
+Determine whether this is a **new project** or a **feature for the current project**.
 
-**Signals this is a new project:**
+| Signal | Conclusion |
+|--------|------------|
+| User says "new app", "new project", "build from scratch"; no relevant code in working directory | New project |
+| User references existing code/screens; idea extends current functionality | Feature for current project → skip to Step 0.1 |
 
-- User says "new app", "new project", "create a …", "build a … from scratch"
-- The described work has no relation to the current codebase
-- No existing code, packages, or patterns in the working directory are relevant
+**If new project**, use **AskUserQuestion**: "This sounds like a new project. Where would you like to work?"
 
-**Signals this is a feature for the current project:**
-
-- User references existing code, screens, or modules
-- The idea extends or modifies current functionality
-- The working directory contains a codebase related to the description
-
-**If this appears to be a new project**, use **AskUserQuestion tool**:
-
-**Question:** "This sounds like a new project. Where would you like to work?"
-
-**Options:**
-
-1. **Create project first** — scaffold the project with `/create`, open it in your editor, then brainstorm in that workspace. This keeps all artifacts, plans, and code in the right place from the start.
-2. **Continue here** — brainstorm in the current workspace. You'll need to move artifacts and switch workspaces later.
-
-**If the user selects "Create project first"** → output the following (interpolating the user's feature description into step 3) and then stop:
-
-```md
-To get started in the right workspace:
-
-1. Run `/create` to scaffold your project
-2. Open the new project folder in your editor
-3. Run `/brainstorm <original feature description>` in that workspace to continue
-
-This ensures all brainstorm docs, plans, and code land in the correct project from the start.
-
-> If `/create` does not support your project type, you can create the project manually, open it, and then run step 3.
-```
-
-**If the user selects "Continue here"** → proceed to Step 0.1.
-
-**If this is clearly a feature for the current project** → proceed to Step 0.1 directly. Do not ask.
+1. **Create project first (Recommended)** — output instructions to run `/create`, open the new folder, then `/brainstorm <description>` in that workspace. Then stop.
+2. **Continue here** — proceed to Step 0.1
 
 ### 0.1. Assess clarity of requirements
 
-Before diving into questions, assess whether brainstorming is needed.
+Assess whether brainstorming is needed.
 
-**Signals that requirements are clear:**
+| Requirements are clear | Brainstorming is needed |
+|------------------------|------------------------|
+| Specific acceptance criteria provided | Vague terms ("make it better", "add something like") |
+| Exact behavior described, scope constrained | Multiple reasonable interpretations, trade-offs undiscussed |
 
-- User provided specific acceptance criteria
-- User referenced existing patterns to follow
-- User described exact behavior expected
-- Scope is constrained and well-defined
-
-**Signals that brainstorming is needed:**
-
-- User used vague terms ("make it better", "add something like")
-- Multiple reasonable interpretations exist
-- Trade-offs haven't been discussed
-- User seems unsure about the approach
-
-**If requirements are clear:** Use **AskUserQuestion tool** to let the user know: "Your requirements seem clear. Consider proceeding directly to planning or implementation."
+**If clear:** Use **AskUserQuestion** to suggest proceeding directly to planning.
 
 ### 1. Understand the idea
 
@@ -97,22 +59,7 @@ Focus on: similar features, established patterns, CLAUDE.md guidance.
 
 Use the **AskUserQuestion tool** to ask questions one at a time. The tool automatically provides an "Other" option for free-text input — never add your own catch-all option (e.g., "Something else", "None of the above").
 
-**Question Techniques:**
-
-1. **Prefer multiple choice when natural options exist**
-   - Good: "Should the notification be: (a) email only, (b) in-app only, or (c) both?"
-   - Avoid: "How should users be notified?"
-
-2. **Start broad, then narrow**
-   - First: What is the core purpose?
-   - Then: Who are the users?
-   - Finally: What constraints exist?
-
-3. **Validate assumptions explicitly**
-   - "I'm assuming users will be logged in. Is that correct?"
-
-4. **Ask about success criteria early**
-   - "How will you know this feature is working well?"
+**Question Techniques:** Prefer multiple choice over open-ended. Start broad (purpose, users) then narrow (constraints, edge cases). Validate assumptions explicitly. Ask about success criteria early.
 
 **Key Topics to Explore:**
 

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -36,35 +36,20 @@ ls -1 docs/plan/*.md 2>/dev/null || echo "(no plans found)"
 
 ## Phase 0 — Load Plan
 
-**If the plan path above is empty:**
-
-1. Check the available plans listed above.
-
-Then:
-
-1. **If exactly one plan exists:** Read the plan, announce "Found plan: [title]. Using this for implementation.", and proceed with it. No need to ask the user.
-2. **If multiple plans exist:** Use **AskUserQuestion** to ask which plan to execute, listing each plan filename with a brief summary from the first heading.
-3. **If no plans exist:** Tell the user: "No plans found in `docs/plan/`. Run `/plan` first to create an implementation plan."
+| Plan path | Plans in `docs/plan/` | Action |
+|-----------|-----------------------|--------|
+| Provided | — | Read the file. If missing, suggest running `/plan` |
+| Empty | One | Read it, announce "Found plan: [title]", proceed |
+| Empty | Multiple | **AskUserQuestion**: list each with summary, ask which to use |
+| Empty | None | Tell user to run `/plan` first |
 
 Do not proceed without a plan.
 
-**If the plan path is provided:**
+**After loading the plan:** parse title, type, acceptance criteria, tasks, and file paths. Summarize scope to the user, then use **AskUserQuestion** to confirm:
 
-1. Read the plan file
-2. If the file doesn't exist, tell the user and suggest running `/plan`
-
-**After loading the plan:**
-
-1. Parse the plan and extract:
-   - Title and type (feat, fix, refactor, etc.)
-   - Acceptance criteria
-   - Implementation tasks/phases
-   - File paths referenced
-2. Summarize the scope to the user: number of tasks, files to create/modify, estimated complexity
-3. Use **AskUserQuestion** to confirm:
-   - **Start building (Recommended)**: proceed with implementation
-   - **Review the plan first**: open the plan file for the user to review
-   - **Adjust scope**: accept user input on what to change
+- **Start building (Recommended)**: proceed with implementation
+- **Review the plan first**: open the plan file for review
+- **Adjust scope**: accept user input on what to change
 
 Do not proceed until the user selects "Start building."
 
@@ -84,13 +69,7 @@ Work through each task/phase in the plan, in order. For each task:
 
 ### Step 1: Implement
 
-Write code following VGV conventions:
-
-- **Layer order**: Data → Domain → Presentation. Build dependencies before dependents.
-- **State management**: Use the project's chosen state management tool, following VGV conventions.
-- **Style**: Follow VGV naming and style conventions. Detect the project's linter and formatter.
-- **File naming**: Follow the project's existing patterns.
-- **Imports**: Respect layer boundaries. Presentation never imports data directly.
+Write code following VGV conventions. Build layers in dependency order (Data → Domain → Presentation). Use the project's state management tool, naming patterns, linter, and formatter. Respect layer boundaries — presentation never imports data directly.
 
 ### Step 2: Test
 
@@ -184,17 +163,9 @@ Remove the review reports — their findings have already been addressed or reco
 rm -rf docs/reviews/
 ```
 
-### Open PR
-
-Call the **create-pr** skill with `skip-checks` (validation already ran above):
-
-```bash
-/create-pr skip-checks
-```
-
 ### Commit
 
-Stage all implementation and fix changes. Write a commit message:
+Stage all implementation and fix changes. Use this commit format:
 
 ```text
 <type>: <concise description of what was built>
@@ -204,12 +175,9 @@ Implements <plan title or summary>.
 
 Where `<type>` matches the plan's type (`feat`, `fix`, `refactor`, etc.).
 
-### Pull Request
+### Ship
 
-Push the branch and create a PR using `gh pr create`:
-
-- **Title**: `<type>: <concise description>` (under 70 characters)
-- **Body**: Use the [PR template](references/pr-template.md)
+Call `/create-pr skip-checks` to push and open a PR. Validation already ran above. The PR body uses the [PR template](references/pr-template.md).
 
 ### Post-Ship
 

--- a/skills/debrief/SKILL.md
+++ b/skills/debrief/SKILL.md
@@ -47,57 +47,29 @@ The skill must work with partial information. Not every debrief has full CI logs
 
 Based on the incident context, automatically collect evidence. Run these in parallel where possible:
 
-#### 2.1 Git history
+Run these in parallel:
 
-Search for commits and changes related to the incident:
-
-- Identify affected files from the incident description
-- Run `git log` on those files to find recent changes (last 2 weeks or a user-specified time range)
-- Run `git log --all --oneline` with relevant date ranges to find related commits
-- If PR numbers are provided, use `gh pr view <number>` to gather PR details and review comments
-
-#### 2.2 CI/CD evidence
-
-If the user provided CI run references or if recent failures are findable:
-
-- Use `gh run list` to find recent failed CI runs (if applicable)
-- Use `gh run view <id>` for specific runs the user referenced
-- Skip this step if no CI context is available — do not block on missing CI data
-
-#### 2.3 Affected file analysis
-
-For each file identified as part of the incident:
-
-- Check test coverage: are there test files for the affected code? Use Glob to search for corresponding test files.
-- Check recent change frequency: `git log --oneline <file>` to see how often it changed recently
-- Note any files that lack tests or have high churn
+- **Git history**: `git log` on affected files (last 2 weeks or user-specified range), `git log --all --oneline` for related commits, `gh pr view` for referenced PRs
+- **CI/CD evidence**: `gh run list` for recent failures, `gh run view <id>` for referenced runs. Skip if no CI context — do not block on missing data.
+- **Affected file analysis**: Check test coverage (Glob for test files), recent change frequency (`git log --oneline <file>`). Note files lacking tests or with high churn.
 
 ### 3. Analyze root cause
 
-Synthesize the gathered evidence to identify:
+Synthesize the evidence to identify the **root cause** (specific change, gap, or condition — trace to commits or code paths) and **contributing factors** (missing tests, no monitoring, unclear ownership, insufficient review).
 
-1. **Root cause**: The specific change, gap, or condition that caused the incident. Trace to specific commits or code paths where possible.
-2. **Contributing factors**: Conditions that made the incident more likely, harder to detect, or slower to resolve. Examples:
-   - Missing test coverage for the affected path
-   - No monitoring or alerting on the failure mode
-   - Unclear ownership of the affected component
-   - Missing validation or error handling
-   - Insufficient review of the change that introduced the issue
-
-**Blameless framing:** Focus on systems and processes, not individuals. Use "the change" not "developer X's change." Ask "what made this possible?" not "who caused this?"
+**Blameless framing:** Focus on systems and processes, not individuals. Ask "what made this possible?" not "who caused this?"
 
 ### 4. Draft action items
 
-Generate concrete, assignable follow-ups. Each action item must be:
+Generate concrete, assignable follow-ups. Each must be specific (not "improve testing"), linked to code where possible, and categorized:
 
-- **Specific**: "Add integration test for payment webhook retry logic" not "improve testing"
-- **Linked to code where possible**: Reference specific files, functions, or paths that need changes
-- **Categorized by type**:
-  - **Prevent**: Changes that would have prevented this incident (e.g., add validation, add test)
-  - **Detect**: Changes that would have caught it sooner (e.g., add monitoring, add CI check)
-  - **Respond**: Changes that would have made recovery faster (e.g., add runbook, add feature flag)
+| Type | Purpose | Examples |
+|------|---------|----------|
+| **Prevent** | Would have stopped this incident | Add validation, add test |
+| **Detect** | Would have caught it sooner | Add monitoring, add CI check |
+| **Respond** | Would have made recovery faster | Add runbook, add feature flag |
 
-Action items are recorded in the document only. They become separate tickets — the debrief skill does not make code changes.
+Action items are recorded in the document only — they become separate tickets.
 
 ### 5. Set up workspace
 

--- a/skills/hotfix/SKILL.md
+++ b/skills/hotfix/SKILL.md
@@ -61,31 +61,15 @@ git rev-parse --abbrev-ref HEAD
 
 ### Blast Radius Check
 
-Before writing any code, outline the planned change:
+Before writing any code, outline which files and layers the fix touches.
 
-- Which files will be modified
-- Which layers are touched
-- Estimated lines changed
+**If >5 files, multiple layers, or new abstractions needed:** warn the user and use **AskUserQuestion**: (1) Proceed with hotfix, (2) Switch to `/plan`.
 
-**If the fix touches more than 5 files, spans multiple layers, or requires new abstractions:** warn the user:
-
-> This fix has a large blast radius (<N> files across <layers>). Consider switching to the full `/plan` → `/build` workflow for a more structured approach.
-
-Use **AskUserQuestion** with options:
-
-1. **Proceed with hotfix** — continue, accepting the risk
-2. **Switch to /plan** — abort hotfix, start planning
-
-**If the fix is contained (≤5 files, single layer or tightly coupled area):** proceed directly.
+**If contained (≤5 files, single layer):** proceed directly.
 
 ### Step 1: Implement
 
-Write the minimal change that addresses the root cause:
-
-- **Minimal diff**: change only what is necessary. No drive-by refactors, no "while I'm here" improvements.
-- **Scope guard**: if you find yourself touching code unrelated to the bug, stop and flag it to the user as scope creep.
-- **Leave TODOs for follow-up**: if you notice related issues, tech debt, or improvements that are out of scope for this hotfix, add `// TODO(hotfix): <description>` comments in the code so they can be addressed later in a proper `/plan` → `/build` cycle.
-- **Follow existing patterns**: match the style and conventions of the surrounding code.
+Write the minimal change that addresses the root cause. Change only what is necessary — no drive-by refactors. If you touch unrelated code, stop and flag scope creep. Leave `// TODO(hotfix): <description>` comments for out-of-scope issues. Match surrounding code style.
 
 ### Step 2: Test
 
@@ -155,12 +139,9 @@ rm -rf docs/hotfix-review/
 
 Run the project's formatter, linter, and test runner one last time. Fix any failures before proceeding.
 
-### Commit
+### Ship
 
-Create a single, cherry-pick-friendly commit:
-
-- Stage only the files related to the fix (no unrelated changes).
-- Write a commit message in this format:
+Create a single, cherry-pick-friendly commit. Stage only fix-related files (no unrelated changes). Use this commit format:
 
 ```text
 fix: <concise description of what was fixed>
@@ -170,12 +151,7 @@ fix: <concise description of what was fixed>
 Bug: <original bug description or issue link, truncated if long>
 ```
 
-### Pull Request
-
-Push the branch and create a PR using `gh pr create`:
-
-- **Title**: `fix: <concise description>` (under 70 characters)
-- **Body**: Use the [PR template](references/pr-template.md)
+Push the branch and create a PR. **Title**: `fix: <concise description>` (under 70 chars). **Body**: Use the [PR template](references/pr-template.md).
 
 ### Post-Ship
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -17,43 +17,23 @@ Transform feature descriptions, bug reports, or improvement ideas into well-stru
 
 ### 0. Idea Refinement
 
-**Check for brainstorm output first — before asking the user anything:**
-
-Look for recent brainstorm documents in `docs/brainstorm`:
+Check for brainstorm output first — before asking the user anything.
 
 ```bash
 ls -la docs/brainstorm/*.md 2>/dev/null | head -10
 ```
 
-**Relevance criteria:** A brainstorm is relevant if:
+A brainstorm is relevant if created within the last 7 days and its topic semantically matches the feature description (if provided).
 
-- Created within the last 7 days
-- If a feature description was provided above, the topic (from filename or YAML frontmatter) semantically matches it
+| Brainstorms found | Feature description provided? | Action |
+|-------------------|------------------------------|--------|
+| One relevant | Yes | Read it, announce "Found brainstorm from [date]: [topic]", extract key decisions, proceed |
+| One relevant | No | **AskUserQuestion**: "Plan this brainstorm?" — (Recommended) use it, or describe something different |
+| Multiple relevant | Either | **AskUserQuestion**: list candidates, ask which to use |
+| None / not relevant | No | Ask: "What would you like to plan?" |
+| None / not relevant | Yes | Run /brainstorm to clarify the idea first |
 
-**If exactly one relevant brainstorm exists and a feature description was provided:**
-
-1. Read the brainstorm document
-2. Announce: "Found brainstorm from [date]: [topic]. Using as context for planning."
-3. Extract key decisions, chosen approach, and open questions
-4. Use brainstorm decisions as input to the research phase
-
-**If exactly one relevant brainstorm exists but NO feature description was provided:**
-
-1. Read the brainstorm document
-2. Use **AskUserQuestion tool**: "I found a recent brainstorm: **[topic]** from [date]. Would you like to plan this, or describe something different?"
-   - **Options:**
-     1. **Plan this brainstorm (Recommended)** — use it as context and derive the feature description from it
-     2. **Describe something different** — ignore the brainstorm and ask what to plan instead
-3. If the user selects "Plan this brainstorm": extract key decisions, chosen approach, and open questions. Derive the feature description from the brainstorm topic.
-4. If the user selects "Describe something different": ask "What would you like to plan?" and proceed without the brainstorm.
-
-**If multiple relevant brainstorms exist:** Use **AskUserQuestion tool** to ask which brainstorm to use, providing a brief summary of each candidate. Derive the feature description from the selected brainstorm if none was provided.
-
-**If no brainstorm found (or not relevant) and no feature description was provided:** Ask the user: "What would you like to plan? Please describe the feature, bug fix, or improvement you have in mind."
-
-**If no brainstorm found but a feature description was provided:** run /brainstorm to clarify the idea before proceeding.
-
-Do not proceed until you have a clear feature description — either from the arguments, a brainstorm document, or the user.
+Do not proceed until you have a clear feature description — from arguments, a brainstorm, or the user.
 
 **Skip option**: if the description is already detailed enough, ask the user if they want to skip idea refinement and proceed directly to planning.
 
@@ -75,18 +55,13 @@ Instead, extract what's needed from the brainstorm and run targeted searches:
 
 Based on the findings from `0. Idea Refinement` and `1.1 Local research`, decide whether external research is needed:
 
-**High-risk topics: always research.** Security, payments, external APIs, personal data, data privacy. The cost of missing something is too high. This takes precedence over speed signals.
+| Signal | Decision |
+|--------|----------|
+| High-risk topic (security, payments, external APIs, personal data) | Always research — cost of missing something is too high |
+| Strong local context (good patterns, CLAUDE.md guidance, clear user intent) | Skip external research |
+| Uncertainty or unfamiliar territory (no codebase examples, new technology) | Research |
 
-**Strong local context: skip external research.** Codebase has good patterns, CLAUDE.md has guidance, user knows what they want. External research adds little value, so don't do it.
-
-**Uncertainty or unfamiliar territory: research.** User is exploring, codebase has no examples, new technology. External perspective is valuable.
-
-**Announce the decision and proceed.** Brief explanation, then continue. User can redirect if needed.
-
-Examples:
-
-- "Your codebase has solid patterns for this. Proceeding without external research."
-- "This involves payment processing, so I'll research current best practices first."
+Announce the decision briefly and proceed. User can redirect if needed.
 
 ###### 1.1.1.1 Conditional external research
 
@@ -149,49 +124,11 @@ After planning the issue structure, run the **user-flow-analysis-agent** to anal
 
 **Default to Standard.** Use a different level only when the task clearly warrants it.
 
-#### Minimal
-
-Use for simple bugs, small enhancements, or when the implementation is straightforward and well-understood.
-
-It includes:
-
-- Problem/feature description
-- Acceptance criteria
-- Essential context
-
-Use the [minimal template](references/minimal.md) for this level.
-
-#### Standard (default)
-
-Use for most features and bug fixes that require a moderate level of detail to ensure clarity and successful implementation.
-
-It includes:
-
-- Everything in Minimal, plus:
-  - Detailed background and motivation
-  - Technical considerations
-  - Success metrics
-  - Dependencies and risks
-  - Basic implementation suggestions
-
-Use the [standard template](references/standard.md) for this level.
-
-#### Extensive
-
-Use for major/complex features, architectural changes, or when the implementation involves significant risk or uncertainty.
-
-It includes:
-
-- Everything in Standard, plus:
-  - Detailed implementation plan with phases
-  - Alternative approaches considered
-  - Extensive technical specifications
-  - Resource requirements and timeline
-  - Future considerations and extensibility
-  - Risk mitigation strategies
-  - Documentation requirements
-
-Use the [extensive template](references/extensive.md) for this level.
+| Level | When to use | Template |
+|-------|-------------|----------|
+| **Minimal** | Simple bugs, small enhancements, straightforward implementation | [minimal](references/minimal.md) |
+| **Standard** (default) | Most features and bug fixes needing moderate detail | [standard](references/standard.md) |
+| **Extensive** | Major features, architectural changes, significant risk or uncertainty | [extensive](references/extensive.md) |
 
 ### 4.1. Set up workspace
 
@@ -201,29 +138,13 @@ Before writing the plan file, ensure the session is on a feature branch:
 
 ### 5. Issue creation and formatting
 
-**Content Formatting:**
+**Formatting checklist:**
 
-- [ ] Use clear, descriptive headings with proper hierarchy (##, ###)
-- [ ] Include code examples in triple backticks with language syntax highlighting
-- [ ] Add screenshots/mockups if UI-related (drag & drop or use image hosting)
-- [ ] Use task lists (- [ ]) for trackable items that can be checked off
-- [ ] Add collapsible sections for lengthy logs or optional details using `<details>` tags
-- [ ] Apply appropriate emoji for visual scanning (🐛 bug, ✨ feature, 📚 docs, ♻️ refactor)
-
-**Cross-Referencing:**
-
-- [ ] Link to related issues/PRs using #number format
-- [ ] Reference specific commits with SHA hashes when relevant
-- [ ] Link to code using GitHub's permalink feature (press 'y' for permanent link)
-- [ ] Mention relevant team members with @username if needed
-- [ ] Add links to external resources with descriptive text
-
-**AI-Era Considerations:**
-
-- [ ] Account for accelerated development with AI-assisted engineering
+- [ ] Clear heading hierarchy (##, ###) and fenced code blocks with language identifiers
+- [ ] Task lists (`- [ ]`) for trackable items; collapsible `<details>` for lengthy content
+- [ ] Link related issues/PRs (`#number`), commits (SHA), and code (GitHub permalinks)
 - [ ] Include prompts or instructions that worked well during research
-- [ ] Emphasize comprehensive testing given rapid implementation
-- [ ] Document any AI-generated code that needs human review
+- [ ] Emphasize comprehensive testing given rapid AI-assisted implementation
 
 ### 6. Final review
 
@@ -244,11 +165,7 @@ Before writing the plan file, ensure the session is on a feature branch:
 Examples:
 
 - ✅ `docs/plan/2026-01-15-feat-user-authentication-flow-plan.md`
-- ✅ `docs/plan/2026-02-03-fix-checkout-race-condition-plan.md`
-- ✅ `docs/plan/2026-03-10-refactor-api-client-extraction-plan.md`
-- ❌ `docs/plan/2026-01-15-feat-thing-plan.md` (not descriptive - what "thing"?)
-- ❌ `docs/plan/2026-01-15-feat-new-feature-plan.md` (too vague - what feature?)
-- ❌ `docs/plan/2026-01-15-feat: user auth-plan.md` (invalid characters - colon and space)
+- ❌ `docs/plan/2026-01-15-feat-thing-plan.md` (not descriptive)
 - ❌ `docs/plan/feat-user-auth-plan.md` (missing date prefix)
 
 ## Post-Generation Options


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description
#145 

<!--- Describe what changed and why. -->

Reduced tokens across 5 skills (build, brainstorm, hotfix, debrief, plan)
The main techniques used: 
- decision tables replacing if/else prose chains, 
- collapsing bullet lists into single sentences, 
- trimming redundant ship/commit sections that delegate to other skills, 
- reducing example counts.

| Skill | Before | After | Reduction |
| ------ | ------ | ------ | ------ |
| plan | 1,829 | 1,357 | 26% |
| build | 1,419 | 1,261 | 11% |
| brainstorm | 1,285 | 987 | 23% |
| hotfix | 1,235 | 1,062 | 14% |
| debrief |1,086 | 893 | 18% |
| Total | 6,854 | 5,560 | 19% |

## Type of Change

<!--- Check the one that applies to this PR. -->

- [ ] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [x] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
