### PR TITLE
fix: simplify shell commands in skills to avoid permission errors

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -28,13 +28,11 @@ Build Progress:
 
 <plan_path>$ARGUMENTS</plan_path>
 
-## Available Plans
-
-```!
-ls -1 docs/plan/*.md 2>/dev/null || echo "(no plans found)"
-```
-
 ## Phase 0 — Load Plan
+
+```bash
+ls docs/plan/
+```
 
 | Plan path | Plans in `docs/plan/` | Action |
 |-----------|-----------------------|--------|

--- a/skills/create-pr/references/ci-checks.md
+++ b/skills/create-pr/references/ci-checks.md
@@ -10,10 +10,7 @@ Check for a CI configuration file in this order:
 2. **GitLab CI:** `.gitlab-ci.yml`
 3. **Fallback:** no CI configuration found — skip CI checks entirely.
 
-```bash
-cat .github/workflows/ci.yaml 2>/dev/null \
-  || cat .gitlab-ci.yml 2>/dev/null
-```
+Read whichever file exists first. Use the **Read** tool — do not use `cat`.
 
 If no file is found, skip CI checks entirely.
 

--- a/skills/create-pr/references/pull-request-template.md
+++ b/skills/create-pr/references/pull-request-template.md
@@ -10,10 +10,7 @@ Check for a project-level template in this order:
 2. **GitLab:** `.gitlab/merge_request_templates/Default.md`
 3. **Fallback:** use the default template below.
 
-```bash
-cat .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null \
-  || cat .gitlab/merge_request_templates/Default.md 2>/dev/null
-```
+Read whichever file exists first. Use the **Read** tool — do not use `cat`.
 
 If a project-level template is found, use it as the structure. Strip HTML comments and pre-fill where possible.
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -20,7 +20,7 @@ Transform feature descriptions, bug reports, or improvement ideas into well-stru
 Check for brainstorm output first — before asking the user anything.
 
 ```bash
-ls -la docs/brainstorm/*.md 2>/dev/null | head -10
+ls docs/brainstorm/
 ```
 
 A brainstorm is relevant if created within the last 7 days and its topic semantically matches the feature description (if provided).


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Closes #164.

Chained shell commands (pipes, `||`, `2>/dev/null`) in skill files trigger the Claude Code permission checker, blocking new users on first invoke. Simplified:

- build: remove auto-exec block, move plan discovery into Phase 0
- plan: plain `ls` for brainstorm listing
- review: drop pipe/stderr redirect from `git symbolic-ref`
- create-pr: replace chained `cat` with Read tool instructions

## Type of Change

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)