### PR TITLE
fix: make /build handoff command single-click copyable 

### DIFF
--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -131,11 +131,11 @@ Use **AskUserQuestion tool** to consider next steps:
 
 When `refine-approach` is complete, present these options:
 
-1. **Clear context and plan**: follow the [clear context handoff](references/clear-context-handoff.md) for `/plan`
+1. **Clear context and plan (Recommended)**: clear context for a fresh start, then plan
 2. **Move to planning**: run the `/plan` skill to create a detailed implementation plan
 3. **Done for now**: ideation complete. To start planning later: `/plan`
 
-**If the user selects "Clear context and plan"** → output the same instructions as above and then stop.
+**If the user selects "Clear context and plan"** → Follow the [clear context handoff](references/clear-context-handoff.md) for `/plan` with the actual brainstorm doc path. Then stop.
 
 ## Output Summary
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -181,9 +181,10 @@ After writing the plan file, use the **AskUserQuestion tool** and present the fo
 4. **Run `/plan-technical-review` on this plan**: run the technical review skill to validate the plan
 5. **Review and refine**: improve the plan through self-review
 
-Based on selection:
+**If the user selects "Clear context and build"** → Follow the [clear context handoff](references/clear-context-handoff.md) for `/build` with the actual plan file path. Then stop.
 
-- **Clear context and build** → Follow the [clear context handoff](references/clear-context-handoff.md) for `/build` with the actual plan file path. Then stop.
+**For other selections:**
+
 - **Start building** → Call the `/build` skill with the plan file path
 - **Open plan in editor** → Run `open docs/plan/<plan_filename>.md` to open the file in the user's default editor
 - **`/plan-technical-review`** → Call the `/plan-technical-review` skill with the plan file path


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Closes #163.

Move code block out of indented bullet so it renders as a standalone copyable block, matching the brainstorm → plan handoff format.

## Type of Change

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)