### PR TITLE
fix: remove unused Figma MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,5 @@
 {
   "mcpServers": {
-    "figma": {
-      "url": "https://mcp.figma.com/mcp",
-      "type": "http"
-    },
     "context7": {
       "command": "npx",
       "args": [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Closes #168.

Removes unused Figma MCP server entry from `.mcp.json`. No skills or agents reference Figma — wastes tokens and conflicts with repos that configure Figma MCP locally.

## Type of Change

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)