### PR TITLE
feat: add intelligent conflict resolution to rebase skill

### DIFF
--- a/skills/rebase/SKILL.md
+++ b/skills/rebase/SKILL.md
@@ -4,8 +4,8 @@ user-invocable: true
 disable-model-invocation: true
 description: Rebases the current feature branch onto the base branch (main/master/develop).
 when_to_use: Use when user says "rebase", "sync branch", or "update branch".
-allowed-tools: Bash(*/scripts/detect-base-branch.sh) Bash(git fetch *) Bash(git rebase *) Bash(git stash *) Bash(git rev-parse *) Bash(git rev-list *) Bash(git status *) Bash(git merge-base *) Bash(git diff *) Bash(git add *)
-effort: low
+allowed-tools: Bash(*/scripts/detect-base-branch.sh) Bash(git fetch *) Bash(git rebase *) Bash(GIT_EDITOR=true git rebase *) Bash(git stash *) Bash(git rev-parse *) Bash(git rev-list *) Bash(git status *) Bash(git merge-base *) Bash(git diff *) Bash(git add *) Read Edit
+effort: medium
 compatibility: Designed for Claude Code (or similar products with git access)
 ---
 
@@ -118,21 +118,23 @@ git add <resolved-file>
 ### 4c. Continue the rebase
 
 ```bash
-git rebase --continue
+GIT_EDITOR=true git rebase --continue
 ```
 
-Multi-commit rebases may produce conflicts at multiple steps. Repeat 4a-4c for each.
+`GIT_EDITOR=true` stops `git` from opening an interactive editor for the commit message, which would otherwise hang with no terminal attached.
+
+Multi-commit rebases may produce conflicts at multiple steps. Repeat 4a-4c for each. If `git rebase --continue` fails for a reason other than conflicts — for example, a pre-commit hook rejects the commit — stop and report the failure rather than looping.
 
 ### 4d. After all conflicts are resolved, report
 
 - Every conflict that was resolved, with a one-line explanation of what you chose
 - Any files flagged for regeneration
-- Suggest running the project's build/test/format/analyze commands to verify correctness
+- Suggest running the project's own build, test, and format/lint checks to verify correctness
 - If the branch was previously pushed, mention that a force-push (`git push --force-with-lease`) will be needed — but do NOT push automatically
 
 If changes were stashed in Step 1, restore them with `git stash pop`. If `stash pop` fails due to conflicts, inform the user and suggest `git stash show` to review the stashed changes.
 
-## Step 5: Recovery
+## Recovery (if needed)
 
 If the rebase enters a bad state or a conflict is too ambiguous to resolve safely:
 

--- a/skills/rebase/SKILL.md
+++ b/skills/rebase/SKILL.md
@@ -75,9 +75,10 @@ Report success briefly:
 
 - How many commits were replayed (`git rev-list --count origin/<base-branch>..HEAD`)
 - The branch is now up to date with `origin/<base-branch>`
+- Suggest running the project's own build, test, and format/lint checks — a clean rebase can still introduce semantic conflicts
 - If the branch was previously pushed, mention that a force-push (`git push --force-with-lease`) will be needed to update the remote — but do NOT push automatically
 
-If changes were stashed in Step 1, restore them with `git stash pop`. If stash pop fails due to conflicts, inform the user and suggest `git stash show` to review the stashed changes.
+If changes were stashed in Step 1, restore them with `git stash pop` (see Step 4d if the pop conflicts).
 
 ## Step 4: Handling conflicts
 
@@ -156,6 +157,7 @@ If changes were stashed in Step 1, restore them with `git stash pop`.
 - Never squash, reorder, or edit commits during the rebase — just replay them.
 - Never proceed on a dirty working tree without the user's consent.
 - Prefer keeping both sides' changes when combining — err on the side of inclusion.
-- After resolving conflicts, always recommend running build, test, format, and analyze to verify.
-- This skill only manages git state. Do not modify project files outside of conflict resolution.
+- Stage only the files you resolved — never `git add -A`.
+- After resolving conflicts, always recommend running the project's own build, test, and format/lint checks to verify.
+- Modify project files only to resolve rebase conflicts — make no other code changes.
 - If changes were stashed, always restore them — even if the rebase fails.

--- a/skills/rebase/SKILL.md
+++ b/skills/rebase/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: true
 disable-model-invocation: true
 description: Rebases the current feature branch onto the base branch (main/master/develop).
 when_to_use: Use when user says "rebase", "sync branch", or "update branch".
-allowed-tools: Bash(*/scripts/detect-base-branch.sh) Bash(git fetch *) Bash(git rebase *) Bash(git stash *)
+allowed-tools: Bash(*/scripts/detect-base-branch.sh) Bash(git fetch *) Bash(git rebase *) Bash(git stash *) Bash(git rev-parse *) Bash(git rev-list *) Bash(git status *) Bash(git merge-base *) Bash(git diff *) Bash(git add *)
 effort: low
 compatibility: Designed for Claude Code (or similar products with git access)
 ---

--- a/skills/rebase/SKILL.md
+++ b/skills/rebase/SKILL.md
@@ -96,16 +96,15 @@ Read the full file content and locate conflict markers (`<<<<<<<`, `=======`, `>
 **Auto-resolve** (the right answer is clear):
 
 - Both sides added imports or list items — combine both sets, deduplicate, maintain sort order
-- Generated or lock files (anything produced by a build step or dependency resolver rather than edited by hand) — take the current branch version; note that regeneration is needed after rebase completes
+- Generated or lock files (anything produced by a build step or dependency resolver rather than edited by hand) — keep your feature branch's version (the change being replayed), then note that regeneration is needed after the rebase completes. Caution: during a rebase `--ours` is the base branch and `--theirs` is your commit — the reverse of a merge — so resolve by reading the content, not by reaching for `--ours`/`--theirs`.
 - Formatting / whitespace-only diffs — accept either side
 - One side added new code, the other didn't touch that region — take the addition
-- One side modified code the other side deleted — prefer the modification, but mention it in the summary so the user can verify the deletion wasn't intentional
+- One side modified code the other side deleted — prefer the modification, but call this out prominently in the summary and ask the user to confirm the deletion wasn't intentional, since keeping the change resurrects a file the other side removed
 
 **Stop and ask the user** (the right answer requires judgment):
 
 - Both sides changed the same function or logic block differently
 - Business logic where correctness depends on product intent
-- Anything you aren't confident about
 
 When in doubt, ask. Losing someone's work is far worse than pausing to check.
 

--- a/skills/rebase/SKILL.md
+++ b/skills/rebase/SKILL.md
@@ -96,7 +96,7 @@ Read the full file content and locate conflict markers (`<<<<<<<`, `=======`, `>
 **Auto-resolve** (the right answer is clear):
 
 - Both sides added imports or list items — combine both sets, deduplicate, maintain sort order
-- Generated files (`.g.dart`, `.freezed.dart`, `.gen.dart`, lock files) — take the current branch version; note that regeneration is needed after rebase completes
+- Generated or lock files (anything produced by a build step or dependency resolver rather than edited by hand) — take the current branch version; note that regeneration is needed after rebase completes
 - Formatting / whitespace-only diffs — accept either side
 - One side added new code, the other didn't touch that region — take the addition
 - One side modified code the other side deleted — prefer the modification, but mention it in the summary so the user can verify the deletion wasn't intentional

--- a/skills/rebase/SKILL.md
+++ b/skills/rebase/SKILL.md
@@ -69,36 +69,92 @@ If they match, the branch is already up-to-date. Inform the user and stop.
 git rebase origin/<base-branch>
 ```
 
-### On success
+### Clean rebase (no conflicts)
 
-Report how many commits ahead of the base branch:
+Report success briefly:
+
+- How many commits were replayed (`git rev-list --count origin/<base-branch>..HEAD`)
+- The branch is now up to date with `origin/<base-branch>`
+- If the branch was previously pushed, mention that a force-push (`git push --force-with-lease`) will be needed to update the remote — but do NOT push automatically
+
+If changes were stashed in Step 1, restore them with `git stash pop`. If stash pop fails due to conflicts, inform the user and suggest `git stash show` to review the stashed changes.
+
+## Step 4: Handling conflicts
+
+When `git rebase` stops with conflicts:
+
+### 4a. Identify conflicted files
 
 ```bash
-git rev-list --count origin/<base-branch>..HEAD
+git diff --name-only --diff-filter=U
 ```
 
-### On conflict
+### 4b. Resolve each conflicted file
 
-Abort the rebase:
+Read the full file content and locate conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`). For each conflict chunk, decide:
+
+**Auto-resolve** (the right answer is clear):
+
+- Both sides added imports or list items — combine both sets, deduplicate, maintain sort order
+- Generated files (`.g.dart`, `.freezed.dart`, `.gen.dart`, lock files) — take the current branch version; note that regeneration is needed after rebase completes
+- Formatting / whitespace-only diffs — accept either side
+- One side added new code, the other didn't touch that region — take the addition
+- One side modified code the other side deleted — prefer the modification, but mention it in the summary so the user can verify the deletion wasn't intentional
+
+**Stop and ask the user** (the right answer requires judgment):
+
+- Both sides changed the same function or logic block differently
+- Business logic where correctness depends on product intent
+- Anything you aren't confident about
+
+When in doubt, ask. Losing someone's work is far worse than pausing to check.
+
+After resolving all conflicts in a file, write the clean version and stage it:
+
+```bash
+git add <resolved-file>
+```
+
+### 4c. Continue the rebase
+
+```bash
+git rebase --continue
+```
+
+Multi-commit rebases may produce conflicts at multiple steps. Repeat 4a-4c for each.
+
+### 4d. After all conflicts are resolved, report
+
+- Every conflict that was resolved, with a one-line explanation of what you chose
+- Any files flagged for regeneration
+- Suggest running the project's build/test/format/analyze commands to verify correctness
+- If the branch was previously pushed, mention that a force-push (`git push --force-with-lease`) will be needed — but do NOT push automatically
+
+If changes were stashed in Step 1, restore them with `git stash pop`. If `stash pop` fails due to conflicts, inform the user and suggest `git stash show` to review the stashed changes.
+
+## Step 5: Recovery
+
+If the rebase enters a bad state or a conflict is too ambiguous to resolve safely:
 
 ```bash
 git rebase --abort
 ```
 
+This restores the branch to its exact pre-rebase state — nothing is lost. Explain what went wrong so the user can decide how to proceed.
+
 If changes were stashed in Step 1, restore them with `git stash pop`.
-
-Inform the user that the rebase had conflicts and suggest resolving manually:
-
-> Automatic rebase failed due to conflicts. To resolve manually, run: `git rebase origin/<base-branch>`
 
 ## Gotchas
 
-- If the branch has already been pushed to a remote, rebasing rewrites history. The user will need to force-push (`git push --force-with-lease`) after a successful rebase — warn them.
-- `git stash pop` can itself cause conflicts if stashed changes overlap with rebased commits. If stash pop fails, inform the user and suggest `git stash show` to review the stashed changes.
 - Detached HEAD state (`HEAD` instead of a branch name) means the user is not on any branch. Inform them and stop — do not attempt to rebase.
 - If the base branch does not exist locally but does on the remote, `git fetch` in Step 2 will create the remote tracking ref. The rebase uses `origin/<base-branch>`, not the local branch.
 
-## Important
+## Rules
 
-- This skill only manages git state. Do not modify project files.
+- Never force-push unless the user explicitly asks.
+- Never squash, reorder, or edit commits during the rebase — just replay them.
+- Never proceed on a dirty working tree without the user's consent.
+- Prefer keeping both sides' changes when combining — err on the side of inclusion.
+- After resolving conflicts, always recommend running build, test, format, and analyze to verify.
+- This skill only manages git state. Do not modify project files outside of conflict resolution.
 - If changes were stashed, always restore them — even if the rebase fails.

--- a/skills/rebase/SKILL.md
+++ b/skills/rebase/SKILL.md
@@ -4,7 +4,7 @@ user-invocable: true
 disable-model-invocation: true
 description: Rebases the current feature branch onto the base branch (main/master/develop).
 when_to_use: Use when user says "rebase", "sync branch", or "update branch".
-allowed-tools: Bash(*/scripts/detect-base-branch.sh) Bash(git fetch *) Bash(git rebase *) Bash(GIT_EDITOR=true git rebase *) Bash(git stash *) Bash(git rev-parse *) Bash(git rev-list *) Bash(git status *) Bash(git merge-base *) Bash(git diff *) Bash(git add *) Read Edit
+allowed-tools: Bash(*/scripts/detect-base-branch.sh) Bash(git fetch *) Bash(git rebase *) Bash(GIT_EDITOR=true git rebase *) Bash(git stash *) Bash(git rev-parse *) Bash(git rev-list *) Bash(git status *) Bash(git merge-base *) Bash(git diff *) Bash(git add *) Read Edit AskUserQuestion
 effort: medium
 compatibility: Designed for Claude Code (or similar products with git access)
 ---
@@ -106,6 +106,17 @@ Read the full file content and locate conflict markers (`<<<<<<<`, `=======`, `>
 
 - Both sides changed the same function or logic block differently
 - Business logic where correctness depends on product intent
+
+Do not reduce these to a choice between the two sides. Work out what each side was trying to achieve, then draft a resolution that satisfies both intents — the sides conflict textually far more often than they conflict in purpose.
+
+Ask with the **AskUserQuestion tool**, one question per conflict chunk. Option labels are too short to hold code, so first print the conflicting chunk and the resolution you drafted, then offer:
+
+- **Merge both intents**: the drafted resolution. Offer this only when you can state each side's intent in one line and the two are compatible; drop it when the sides encode genuinely contradictory decisions.
+- **Keep the base branch's version**: with a one-line summary of what it does.
+- **Keep your feature branch's version**: with a one-line summary of what it does.
+- **Abort the rebase**: back out to the pre-rebase state and resolve by hand.
+
+Mark the merged resolution `(Recommended)` when you can explain both intents from the code you read. If you had to guess at either one, do not offer it at all — a plausible-looking synthesis of an intent you invented is the one outcome here that loses work silently. Leave every option unmarked when nothing favors one. The tool supplies its own "Other" option for a hand-written resolution, so never add a catch-all of your own.
 
 When in doubt, ask. Losing someone's work is far worse than pausing to check.
 


### PR DESCRIPTION
## Summary

- Replaces the abort-on-conflict behavior with step-by-step conflict resolution: identify conflicted files, auto-resolve clear cases (imports, generated files, whitespace), and ask the user on ambiguous logic changes
- Adds recovery step (`git rebase --abort`) as a safety net for bad states
- Adds explicit rules: no force-push without consent, no squash/reorder, prefer inclusion, always recommend build/test/format/analyze

## Test plan

- [ ] Verify `/rebase` on a branch with no conflicts completes cleanly and reports commit count
- [ ] Verify `/rebase` on a branch with auto-resolvable conflicts (import additions, whitespace) resolves without user intervention
- [ ] Verify `/rebase` on a branch with ambiguous logic conflicts stops and asks the user
- [ ] Verify recovery path aborts cleanly and restores stashed changes
- [ ] Verify force-push is warned about but never executed automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)