### PR TITLE
docs: add one-line terminal install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@
 
 ### From the Marketplace
 
-Inside Claude Code:
+One-line install from your terminal:
+
+```bash
+claude plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace && claude plugin install vgv-wingspan@very_good_claude_marketplace
+```
+
+Or inside an active Claude Code session:
 
 ```bash
 /plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Adds one-line `claude plugin ...` install command to README for terminal install without opening a Claude Code session. Keeps existing inside-session `/plugin` instructions as alternative.

## Type of Change

- [ ] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [x] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)