### PR TITLE
feat(debrief): generate issue previews from action items

### DIFF
--- a/skills/debrief/SKILL.md
+++ b/skills/debrief/SKILL.md
@@ -101,7 +101,13 @@ Use the **AskUserQuestion tool** to present next steps:
 
 **If the user selects "Review and refine"** → apply the @refine-approach skill to the document. When refinement is complete, present these options again (without the refine option).
 
-**If the user selects "Generate issue previews"** → read the action items from the written debrief document and render one preview block per item:
+**If the user selects "Generate issue previews"** → read the action items from the written debrief document, then:
+
+1. **Check for issue templates**: look for `.github/ISSUE_TEMPLATE/` in the project root. Read every `.yaml` or `.yml` file found there (skip `config.yml`).
+
+2. **If templates exist**: render one preview block per action item using the most appropriate template. Map each item to a template based on its content (e.g., a missing test or validation gap → bug report; a new monitoring check → feature request; a dependency update or runbook → chore). Populate every required field defined in the template. Include a `Template:` line naming the chosen template file.
+
+3. **If no templates exist**: fall back to the generic format:
 
 ```text
 ---

--- a/skills/debrief/SKILL.md
+++ b/skills/debrief/SKILL.md
@@ -103,7 +103,7 @@ Use the **AskUserQuestion tool** to present next steps:
 
 **If the user selects "Generate issue previews"** → read the action items from the written debrief document and render one preview block per item:
 
-```
+```text
 ---
 Title: <specific, actionable title>
 Label: prevent | detect | respond

--- a/skills/debrief/SKILL.md
+++ b/skills/debrief/SKILL.md
@@ -96,10 +96,31 @@ Use the **AskUserQuestion tool** to present next steps:
 **Options:**
 
 1. **Review and refine**: improve the document using structured review
-2. **Create action item tickets**: draft GitHub issues from the action items (not implemented yet — note this)
+2. **Generate issue previews**: format action items as ready-to-copy GitHub issue drafts
 3. **Done**: debrief complete
 
 **If the user selects "Review and refine"** → apply the @refine-approach skill to the document. When refinement is complete, present these options again (without the refine option).
+
+**If the user selects "Generate issue previews"** → read the action items from the written debrief document and render one preview block per item:
+
+```
+---
+Title: <specific, actionable title>
+Label: prevent | detect | respond
+Body:
+  ## Context
+  Debrief: docs/debriefs/YYYY-MM-DD-<topic>-debrief.md
+  Root cause: <one-line summary from debrief>
+
+  ## What happened
+  <relevant excerpt from the debrief timeline or root cause section>
+
+  ## What to do
+  <the action item, specific and linked to code/files where possible>
+---
+```
+
+Render all previews in a single fenced block so the user can copy them. Do not call `gh`, `glab`, or any external CLI — output is display only.
 
 ## Output Summary
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description

### Issue #185 

Replace the unimplemented "Create action item tickets" handoff option in /debrief with "Generate issue previews". When selected, the skill reads the written debrief document and renders one ready-to-copy issue draft per action item — including title, category label, and body with debrief context. No CLI calls are made; output is display-only, keeping the skill within its documentation-only contract.

***Example preview format:***
```
Title: Add validation for X before Y
Label: prevent
Body:
  ## Context
  From debrief: docs/debriefs/YYYY-MM-DD-...-debrief.md

  Root cause: ...

  ## What to do
  ...
```

## Type of Change

- [X] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
