### PR TITLE
fix(skills): align frontmatter with latest standards and wire $ARGUMENTS

### DIFF
--- a/agents/quality-review/pr-readiness-review-agent.md
+++ b/agents/quality-review/pr-readiness-review-agent.md
@@ -2,7 +2,6 @@
 name: pr-readiness-review-agent
 description: Checks PR readiness — formatting, static analysis, debug artifacts, and commit hygiene — to catch mechanical issues before opening a pull request.
 model: haiku
-effort: low
 ---
 
 # PR Readiness Review Agent

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: brainstorm
 user-invocable: true
-description: Explores requirements and approaches through collaborative dialogue before planning implementation. Use when user says "brainstorm", "explore idea", "what should we build", "think through this", or "let's discuss approaches".
+description: Explores requirements and approaches through collaborative dialogue before planning implementation.
+when_to_use: Use when user says "brainstorm", "explore idea", "what should we build", "think through this", or "let's discuss approaches".
 argument-hint: feature or idea to explore
 compatibility: Designed for Claude Code (or similar products with agent support)
 ---

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: build
 user-invocable: true
-description: Executes an implementation plan — writes code and tests, runs quality review, and ships a pull request. Use when user says "build this", "implement the plan", "start coding", "execute the plan", or "ship it".
+description: Executes an implementation plan — writes code and tests, runs quality review, and ships a pull request.
+when_to_use: Use when user says "build this", "implement the plan", "start coding", "execute the plan", or "ship it".
 effort: high
 argument-hint: plan file path
 allowed-tools: Bash(rm -rf docs/reviews/)

--- a/skills/create-branch/SKILL.md
+++ b/skills/create-branch/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: create-branch
 user-invocable: true
-description: Sets up a workspace branch or worktree before writing artifacts. Use when user says "create a branch", "set up workspace", "start a feature branch", or "new branch".
+description: Sets up a workspace branch or worktree before writing artifacts.
+when_to_use: Use when user says "create a branch", "set up workspace", "start a feature branch", or "new branch".
 argument-hint: feature name or context
 allowed-tools: Bash(*/scripts/detect-base-branch.sh) Bash(git checkout *)
 effort: low

--- a/skills/create-commit/SKILL.md
+++ b/skills/create-commit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: create-commit
-description: Propose and create conventional commit messages for staged changes. Follows Conventional Commits spec and VGV workflow. Use when user says "commit this", "create a commit", "write a commit message", or "commit my changes".
+description: Propose and create conventional commit messages for staged changes. Follows Conventional Commits spec and VGV workflow.
+when_to_use: Use when user says "commit this", "create a commit", "write a commit message", or "commit my changes".
 argument-hint: "[optional: single-commit | ticket/issue number e.g. VGV-123]"
 allowed-tools: Bash(git commit *) Bash(git add *)
 compatibility: Designed for Claude Code (or similar products with git access)

--- a/skills/create-commit/SKILL.md
+++ b/skills/create-commit/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: create-commit
-description: Propose and create conventional commit messages for staged changes. Follows Conventional Commits spec and VGV workflow.
+description: Propose and create conventional commit messages for staged changes. Follows Conventional Commits spec and VGV workflow. Use when user says "commit this", "create a commit", "write a commit message", or "commit my changes".
 argument-hint: "[optional: single-commit | ticket/issue number e.g. VGV-123]"
 allowed-tools: Bash(git commit *) Bash(git add *)
+compatibility: Designed for Claude Code (or similar products with git access)
 ---
 
 # Create a commit

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: create-pr
 description: Stage, commit, push, and open a pull request following project conventions and the Conventional Commits spec. Accepts optional skip-checks argument to bypass validation when called from /build.
+when_to_use: Use when user says "create a PR", "open a PR", "ship it", "submit a pull request", or "open a merge request".
 argument-hint: "[optional: skip-checks | ticket/issue number e.g. VGV-123 | short description]"
 disable-model-invocation: true
 allowed-tools: Bash(git push *) Bash(git add *) Bash(git commit *) Bash(gh *) Bash(glab *)
+compatibility: Designed for Claude Code (or similar products with git access)
 ---
 
 # Create a pull request

--- a/skills/create/SKILL.md
+++ b/skills/create/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: create
 user-invocable: true
-description: Scaffolds a new project by routing to the right companion plugin's create skill. Use when user says "create a project", "new flutter app", "start a dart package", "scaffold", or asks to set up a new codebase.
+description: Scaffolds a new project by routing to the right companion plugin's create skill.
+when_to_use: Use when user says "create a project", "new flutter app", "start a dart package", "scaffold", or asks to set up a new codebase.
 argument-hint: what to create (e.g., "flutter app", "dart package")
 effort: low
 allowed-tools: Read Glob Skill

--- a/skills/debrief/SKILL.md
+++ b/skills/debrief/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: debrief
 user-invocable: true
-description: Produces a structured post-incident analysis — timeline, root cause, and actionable follow-ups — while context is fresh. Use when user says "debrief", "post-mortem", "incident review", or "root cause analysis".
+description: Produces a structured post-incident analysis — timeline, root cause, and actionable follow-ups — while context is fresh.
+when_to_use: Use when user says "debrief", "post-mortem", "incident review", or "root cause analysis".
 argument-hint: incident description, PR/commit refs, or error context
 effort: high
 compatibility: Designed for Claude Code (or similar products with agent support)

--- a/skills/elements-of-style/SKILL.md
+++ b/skills/elements-of-style/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: elements-of-style
 user-invocable: false
-description: Applies Strunk's Elements of Style principles when writing or editing prose. Triggers on "write clearly," "edit for style," "improve writing," or tasks requiring clear, vigorous English — documents, emails, reviews.
+description: Applies Strunk's Elements of Style principles when writing or editing prose.
+when_to_use: Triggers on "write clearly," "edit for style," "improve writing," or tasks requiring clear, vigorous English — documents, emails, reviews.
 compatibility: Designed for Claude Code (or similar products)
 ---
 

--- a/skills/plan-technical-review/SKILL.md
+++ b/skills/plan-technical-review/SKILL.md
@@ -9,7 +9,9 @@ compatibility: Designed for Claude Code (or similar products with agent support)
 
 # Plan technical review
 
-Run the following agents in parallel to conduct a comprehensive technical review of the proposed plan:
+**Plan file:** `$ARGUMENTS` (if empty, ask the user for the plan path or pick the most recent file under `docs/plan/`).
+
+Run the following agents in parallel to conduct a comprehensive technical review of the plan at `$ARGUMENTS`. Pass the plan path to each agent:
 
 - @code-simplicity-review-agent: Review the plan for simplicity and clarity. Ensure the implementation is as straightforward as possible while still meeting all requirements.
 - @vgv-review-agent: Review the plan for adherence to Very Good Engineering practices and project conventions. Ensure the implementation follows our established patterns and conventions.

--- a/skills/plan-technical-review/SKILL.md
+++ b/skills/plan-technical-review/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: plan-technical-review
 user-invocable: true
-description: Conducts a comprehensive technical review of an implementation plan, ensuring it meets requirements and follows best practices. Use when user says "review the plan", "is this plan ready", "validate my plan", or "check the plan".
+description: Conducts a comprehensive technical review of an implementation plan, ensuring it meets requirements and follows best practices.
+when_to_use: Use when user says "review the plan", "is this plan ready", "validate my plan", or "check the plan".
 argument-hint: path to plan file
 effort: high
 compatibility: Designed for Claude Code (or similar products with agent support)

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: plan
 user-invocable: true
-description: Turns high-level brainstorming and ideas into well-structured, actionable implementation plans. Use when user says "plan this", "create a plan", "how should we implement", or "write an implementation plan".
+description: Turns high-level brainstorming and ideas into well-structured, actionable implementation plans.
+when_to_use: Use when user says "plan this", "create a plan", "how should we implement", or "write an implementation plan".
 effort: high
 argument-hint: feature, bug fix, or improvement to plan
 compatibility: Designed for Claude Code (or similar products with agent support)

--- a/skills/rebase/SKILL.md
+++ b/skills/rebase/SKILL.md
@@ -2,7 +2,8 @@
 name: rebase
 user-invocable: true
 disable-model-invocation: true
-description: Rebases the current feature branch onto the base branch (main/master/develop). Use when user says "rebase", "sync branch", or "update branch".
+description: Rebases the current feature branch onto the base branch (main/master/develop).
+when_to_use: Use when user says "rebase", "sync branch", or "update branch".
 allowed-tools: Bash(*/scripts/detect-base-branch.sh) Bash(git fetch *) Bash(git rebase *) Bash(git stash *)
 effort: low
 compatibility: Designed for Claude Code (or similar products with git access)

--- a/skills/refine-approach/SKILL.md
+++ b/skills/refine-approach/SKILL.md
@@ -12,9 +12,11 @@ Improve brainstorm and/or planning documents through structured review.
 
 ## Step 1. Get the document that needs review
 
-**If a document is provided** then proceed to `Step 2. Assess`.
+**Document path:** `$ARGUMENTS`
 
-**If no document is provided**, ask the user which document to review. Check `docs/brainstorm/` and `docs/plan/` for recent documents to suggest.
+**If `$ARGUMENTS` is non-empty**, treat it as the document path and proceed to `Step 2. Assess`.
+
+**If `$ARGUMENTS` is empty**, ask the user which document to review. Check `docs/brainstorm/` and `docs/plan/` for recent documents to suggest.
 
 ## Step 2. Assess
 

--- a/skills/refine-approach/SKILL.md
+++ b/skills/refine-approach/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: refine-approach
 user-invocable: true
-description: Reviews and refines brainstorm or planning documents before implementation. Identifies gaps, clarifies assumptions, and ensures the approach is sound. Use when user says "refine this", "review my approach", or "is this ready".
+description: Reviews and refines brainstorm or planning documents before implementation. Identifies gaps, clarifies assumptions, and ensures the approach is sound.
+when_to_use: Use when user says "refine this", "review my approach", or "is this ready".
 argument-hint: path to document to refine
 compatibility: Designed for Claude Code (or similar products with agent support)
 ---

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: review
 user-invocable: true
-description: Runs quality review agents on demand — reviews code, assesses quality, and identifies issues before merging. Use when user says "review this code", "review my code", "code review", "review", "check this code", or "review before merging".
+description: Runs quality review agents on demand — reviews code, assesses quality, and identifies issues before merging.
+when_to_use: Use when user says "review this code", "review my code", "code review", "review", "check this code", or "review before merging".
 argument-hint: "[path/to/files/or/directories (optional)]"
 allowed-tools: Bash(*/scripts/detect-review-scope.sh)
 effort: high


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description

Align skill and agent frontmatter across the plugin with the latest [Claude Code](https://code.claude.com/docs/en/skills) and [Agent Skills open spec](https://agentskills.io/specification).

**Bug fix: `$ARGUMENTS` plumbing**

`plan-technical-review` and `refine-approach` declared `argument-hint` but the body never consumed `$ARGUMENTS`, so positional input the user typed was silently dropped. Wired the substitution into both bodies so the path the user provides reaches the skill content.

**Frontmatter compliance**

- Add `compatibility` field to `create-commit` and `create-pr` for cross-tool portability (open Agent Skills field, already on the rest of the plugin).
- Drop `effort: low` from `pr-readiness-review-agent`. The `effort` field is only supported on Opus 4.7/4.6 and Sonnet 4.6 — silently ignored on Haiku per [model-config docs](https://code.claude.com/docs/en/model-config).

**Authoring split: `description` vs `when_to_use`**

Skills mixed "what it does" with trigger phrases ("Use when user says X, Y, Z") in a single `description`. Split into `description` (what) and `when_to_use` (triggers) per Claude Code skills guidance. Applied to all 13 skills with a trigger tail: `brainstorm`, `build`, `create`, `create-branch`, `create-commit`, `create-pr`, `debrief`, `elements-of-style`, `plan`, `plan-technical-review`, `rebase`, `refine-approach`, `review`. `hotfix` left untouched (no trigger tail).

**Trigger keywords on create-commit**

Added trigger phrases to `create-commit` `when_to_use` so the model auto-invokes on natural language like "commit this" / "write a commit message".

Verified locally:
- `claude plugin validate .` → ✔ Validation passed
- `bash hooks/test_recommend_plugins.sh` → 42/42 pass

Group 1 of a multi-PR audit. Remaining groups (plugin manifest hygiene, CI hook tests, docs) ship in follow-ups.

## Type of Change

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)