### PR TITLE
docs: fix marketplace name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 One-line install from your terminal:
 
 ```bash
-claude plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace && claude plugin install vgv-wingspan@very_good_claude_marketplace
+claude plugin marketplace add VeryGoodOpenSource/very-good-claude-code-marketplace && claude plugin install vgv-wingspan@very-good-claude-code-marketplace
 ```
 
 Or inside an active Claude Code session:
 
 ```bash
-/plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace
-/plugin install vgv-wingspan@very_good_claude_marketplace
+/plugin marketplace add VeryGoodOpenSource/very-good-claude-code-marketplace
+/plugin install vgv-wingspan@very-good-claude-code-marketplace
 ```
 
 ## Getting Started


### PR DESCRIPTION
## Description

The marketplace name is incorrect in the README. Needs updating from `very_good_claude_marketplace` to `very-good-claude-code-marketplace`.

Something that is contributing to the confusion is that, as far as I can understand, the name of the marketplace repo uses "_", but the actual name in the market place uses "-".

See here: https://github.com/VeryGoodOpenSource/very_good_claude_code_marketplace/blob/main/.claude-plugin/marketplace.json

PS: I think there's a related issue in the [Flutter plugin repo](https://github.com/VeryGoodOpenSource/vgv-ai-flutter-plugin).

## Type of Change

<!--- Check the one that applies to this PR. -->

- [x] Documentation (`docs`)
