### PR TITLE
fix: validate-and-fix should prefer MCP tools over shell commands

### DIFF
--- a/skills/shared/references/validate-and-fix.md
+++ b/skills/shared/references/validate-and-fix.md
@@ -1,8 +1,8 @@
 # Validate and Fix
 
-Run static analysis — detect and use the project's linter/analyzer.
+Run static analysis — detect and use the project's linter/analyzer. If MCP tools are available for the project's analyzer, prefer them over shell commands.
 
-Run tests — detect and use the project's test runner.
+Run tests — detect and use the project's test runner. If MCP tools are available for the project's test runner, prefer them over shell commands.
 
 If failures occur:
 - Fix the issue and re-run


### PR DESCRIPTION
## Description

Adds MCP-preference guidance to `validate-and-fix.md` for both static analysis and test runner steps. This matches the guidance already present in `test-quality-review-agent.md` and prevents unnecessary round-trips when companion plugin hooks block direct CLI commands.

Closes #192

## Type of Change

- [x] Bug fix (`fix`)