### PR TITLE
Fix vgv-wingspan installation command on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 One-line install from your terminal:
 
 ```bash
-claude plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace && claude plugin install vgv-wingspan@very_good_claude_marketplace
+claude plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace && claude plugin install vgv-wingspan
 ```
 
 Or inside an active Claude Code session:
 
 ```bash
 /plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace
-/plugin install vgv-wingspan@very_good_claude_marketplace
+/plugin install vgv-wingspan
 ```
 
 ## Getting Started


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — PR templates don't need a top-level heading -->

## Description
This PR aims to fix the installation guidelines, as they weren't properly working when attempting to install the vgv-wingspan plugin within Claude Code session or in bash. 

## Proof
### Error obtained with README instructions
<img width="1504" height="182" alt="image" src="https://github.com/user-attachments/assets/ad0c7b1a-925d-44f9-99ff-988f1841b1f0" />

### With fix
Inside Claude Code session
<img width="647" height="125" alt="image" src="https://github.com/user-attachments/assets/c666becf-f5f4-4b60-8af0-6cc3f4ca7090" />

Bash
```bash
claude plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace && claude plugin install vgv-wingspan                             
✔ Marketplace 'very-good-claude-code-marketplace' already on disk — declared in user settings
✔ Successfully installed plugin: vgv-wingspan@very-good-claude-code-marketplace (scope: user)
```

## Type of Change

- [ ] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [x] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
