### PR TITLE
docs: clarify in-session plugin install steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,19 @@ One-line install from your terminal:
 claude plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace && claude plugin install vgv-wingspan
 ```
 
-Or inside an active Claude Code session:
+Or inside an active Claude Code session, run these as **two separate commands** (the second only after the first completes):
 
-```bash
-/plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace
-/plugin install vgv-wingspan
-```
+1. Add the marketplace:
+
+   ```text
+   /plugin marketplace add VeryGoodOpenSource/very_good_claude_marketplace
+   ```
+
+2. Install the plugin:
+
+   ```text
+   /plugin install vgv-wingspan
+   ```
 
 ## Getting Started
 


### PR DESCRIPTION
## Description

Split the in-session install snippet into two numbered `/plugin` steps and add a note that the second command must run after the first completes. Claude Code requires separate command invocations for `/plugin marketplace add` and `/plugin install`, so the prior single code block could mislead users into pasting both at once.

Also switched the code-block language tag from `bash` to `text` since slash commands are not shell input.

## Type of Change

- [ ] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [x] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)