### PR TITLE
feat(agents): preload elements-of-style skill into prose-heavy agents

### DIFF
--- a/agents/analysis/user-flow-analysis-agent.md
+++ b/agents/analysis/user-flow-analysis-agent.md
@@ -1,5 +1,6 @@
 ---
 name: user-flow-analysis-agent
+skills: [elements-of-style]
 description: Analyzes specifications and feature descriptions for user flow completeness and gap identification. Use when a spec, plan, or feature description needs flow analysis, edge case discovery, or requirements validation.
 model: inherit
 ---

--- a/agents/codebase-review/code-simplicity-review-agent.md
+++ b/agents/codebase-review/code-simplicity-review-agent.md
@@ -1,5 +1,6 @@
 ---
 name: code-simplicity-review-agent
+skills: [elements-of-style]
 description: Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities.
 model: sonnet
 effort: medium

--- a/agents/codebase-review/codebase-review-agent.md
+++ b/agents/codebase-review/codebase-review-agent.md
@@ -1,5 +1,6 @@
 ---
 name: codebase-review-agent
+skills: [elements-of-style]
 description: |
   Conducts a thorough review of the given codebase, ensures code quality standards are met, and validates that the codebase uses consistently the same patterns.
 

--- a/agents/codebase-review/vgv-review-agent.md
+++ b/agents/codebase-review/vgv-review-agent.md
@@ -1,5 +1,6 @@
 ---
 name: vgv-review-agent
+skills: [elements-of-style]
 description: |
   Reviews code against Very Good Ventures engineering standards. Use after implementing features, modifying code, creating new packages, or before opening PRs. Enforces architecture, state management conventions, testing quality, and code simplicity.
 

--- a/agents/quality-review/architecture-review-agent.md
+++ b/agents/quality-review/architecture-review-agent.md
@@ -1,5 +1,6 @@
 ---
 name: architecture-review-agent
+skills: [elements-of-style]
 description: |
   Validates project architecture against VGV standards post-implementation. Use after writing code to verify layer separation, state management correctness, dependency direction, and package structure.
 

--- a/agents/quality-review/test-quality-review-agent.md
+++ b/agents/quality-review/test-quality-review-agent.md
@@ -1,5 +1,6 @@
 ---
 name: test-quality-review-agent
+skills: [elements-of-style]
 description: |
   Reviews test coverage and quality for implementations. Use after code is written to verify every state management unit, repository, and UI component has proper tests following VGV conventions.
 


### PR DESCRIPTION
## Description

Adds `skills: [elements-of-style]` to the frontmatter of six Wingspan agents that produce written reports where prose quality matters. Subagents don't inherit skills from the parent conversation, so without an explicit declaration these agents wrote reports with no style guidance. Preloading the `elements-of-style` skill (~89 lines, Wingspan-internal) injects Strunk's clarity principles into each agent's context at startup.

Agents updated:

- `agents/codebase-review/vgv-review-agent.md`
- `agents/codebase-review/codebase-review-agent.md`
- `agents/codebase-review/code-simplicity-review-agent.md`
- `agents/quality-review/architecture-review-agent.md`
- `agents/quality-review/test-quality-review-agent.md`
- `agents/analysis/user-flow-analysis-agent.md`

Left untouched per the issue: `pr-readiness-review-agent` (mechanical/tabular output, haiku), `plan-splitting-agent` (short structured output), and both research agents.

Closes #188

## Type of Change

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)