### PR TITLE
feat(plan): add machine-checkable success-criteria gate

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -45,7 +45,7 @@ ls docs/plan/
 
 Do not proceed without a plan.
 
-**After loading the plan:** parse title, type, acceptance criteria, tasks, and file paths. Summarize scope to the user, then use **AskUserQuestion** to confirm:
+**After loading the plan:** parse title, type, the `success-criteria` block, tasks, and file paths. Summarize scope to the user, then use **AskUserQuestion** to confirm:
 
 - **Start building (Recommended)**: proceed with implementation
 - **Review the plan first**: open the plan file for review

--- a/skills/plan-technical-review/references/success-criteria.md
+++ b/skills/plan-technical-review/references/success-criteria.md
@@ -1,0 +1,1 @@
+../../shared/references/plan-templates/success-criteria.md

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -119,9 +119,25 @@ After planning the issue structure, run the **user-flow-analysis-agent** to anal
 
 - [ ] Review flow analysis results
 - [ ] Incorporate any identified gaps or edge cases into the issue
-- [ ] Update acceptance criteria based on flow analysis findings
+- [ ] Update success criteria based on flow analysis findings
 
-### 4. Select implementation detail template
+### 4. Success Criteria Gate
+
+Before selecting a template, derive the plan's success criteria and make each one machine-checkable. This block is the contract `/build` consumes, so it must be precise.
+
+**For each criterion, apply one rule — can a command prove this without human judgment?**
+
+- **Yes** → attach `verify: <command>` (exit code 0 = pass).
+- **No, but a human can check it** → attach `verify: manual <numbered steps>`.
+- **Neither (vacuous or unmeasurable, e.g. "make it work", "code is clean")** → reject it and rewrite it into a concrete, provable criterion.
+
+Surface every rejected or rewritten criterion to the user with **AskUserQuestion** before writing the plan file — do not silently change the spec they approved.
+
+These criteria populate the `success-criteria` block that every plan template defines (e.g. [standard](references/standard.md)); fill it in when you write the plan file in Step 6. The template shows the block's shape and the `verify:` convention.
+
+`verify:` commands reflect the project's own toolchain. If the project has a companion verification skill available, its gates are the canonical `verify:` commands.
+
+### 5. Select implementation detail template
 
 **Default to Standard.** Use a different level only when the task clearly warrants it.
 
@@ -131,13 +147,13 @@ After planning the issue structure, run the **user-flow-analysis-agent** to anal
 | **Standard** (default) | Most features and bug fixes needing moderate detail | [standard](references/standard.md) |
 | **Extensive** | Major features, architectural changes, significant risk or uncertainty | [extensive](references/extensive.md) |
 
-### 4.1. Set up workspace
+### 5.1. Set up workspace
 
 Before writing the plan file, ensure the session is on a feature branch:
 
 - Call /create-branch to check and optionally create a working branch or worktree.
 
-### 5. Issue creation and formatting
+### 6. Issue creation and formatting
 
 **Formatting checklist:**
 
@@ -147,7 +163,7 @@ Before writing the plan file, ensure the session is on a feature branch:
 - [ ] Include prompts or instructions that worked well during research
 - [ ] Emphasize comprehensive testing given rapid AI-assisted implementation
 
-### 6. Final review
+### 7. Final review
 
 **Pre-submission Checklist:**
 
@@ -155,7 +171,7 @@ Before writing the plan file, ensure the session is on a feature branch:
 - [ ] Labels accurately categorize the issue
 - [ ] All template sections are complete
 - [ ] Links and references are working
-- [ ] Acceptance criteria are measurable
+- [ ] Success criteria each carry a `verify:` command (or `verify: manual <steps>`)
 - [ ] Add names of files in pseudo code examples and todo lists
 - [ ] Add an ERD mermaid diagram if applicable for new model changes
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -133,7 +133,7 @@ Before selecting a template, derive the plan's success criteria and make each on
 
 Surface every rejected or rewritten criterion to the user with **AskUserQuestion** before writing the plan file — do not silently change the spec they approved.
 
-These criteria populate the `success-criteria` block that every plan template defines (e.g. [standard](references/standard.md)); fill it in when you write the plan file in Step 6. The template shows the block's shape and the `verify:` convention.
+These criteria populate the `success-criteria` block defined in [success-criteria.md](references/success-criteria.md); fill it in when you write the plan file in Step 6. That reference shows the block's shape and the `verify:` convention.
 
 `verify:` commands reflect the project's own toolchain. If the project has a companion verification skill available, its gates are the canonical `verify:` commands.
 

--- a/skills/plan/references/success-criteria.md
+++ b/skills/plan/references/success-criteria.md
@@ -1,0 +1,1 @@
+../../shared/references/plan-templates/success-criteria.md

--- a/skills/shared/references/plan-templates/extensive.md
+++ b/skills/shared/references/plan-templates/extensive.md
@@ -29,42 +29,43 @@ date: YYYY-MM-DD
 #### Phase 1: [Foundation]
 
 - Tasks and deliverables
-- Success criteria
+- Phase exit condition
 - Estimated effort
 
 #### Phase 2: [Core Implementation]
 
 - Tasks and deliverables
-- Success criteria
+- Phase exit condition
 - Estimated effort
 
 #### Phase 3: [Polish & Optimization]
 
 - Tasks and deliverables
-- Success criteria
+- Phase exit condition
 - Estimated effort
 
 ## Alternative Approaches Considered
 
 [Other solutions evaluated and why rejected]
 
-## Acceptance Criteria
+## Success Criteria
 
-### Functional Requirements
+Each criterion names the command that proves it. Use `verify: <command>` (exit 0 = pass) when a command can prove it without human judgment, or `verify: manual <steps>` when only a human can. Reject vacuous criteria like "make it work" — rewrite them as something provable. Fold functional, non-functional, and quality-gate requirements into concrete criteria below.
 
-- [ ] Detailed functional criteria
+```success-criteria
+GOAL: <one sentence describing the intended end state>
 
-### Non-Functional Requirements
+SUCCESS CRITERIA:
+- <functional criterion> | verify: <shell command; exit 0 = pass>
+- <non-functional criterion, e.g. performance/security/accessibility> | verify: <shell command>
+- <quality gate, e.g. coverage threshold> | verify: <shell command>
+- <criterion only a human can check> | verify: manual <numbered human steps>
 
-- [ ] Performance targets
-- [ ] Security requirements
-- [ ] Accessibility standards
+NON-GOALS:
+- <explicitly out of scope>
 
-### Quality Gates
-
-- [ ] Test coverage requirements
-- [ ] Documentation completeness
-- [ ] Code review approval
+VERIFICATION COMMAND: <the non-manual verify commands above joined into one runnable command (e.g. with &&); exit 0 = all green>
+```
 
 ## Success Metrics
 

--- a/skills/shared/references/plan-templates/extensive.md
+++ b/skills/shared/references/plan-templates/extensive.md
@@ -50,22 +50,7 @@ date: YYYY-MM-DD
 
 ## Success Criteria
 
-Each criterion names the command that proves it. Use `verify: <command>` (exit 0 = pass) when a command can prove it without human judgment, or `verify: manual <steps>` when only a human can. Reject vacuous criteria like "make it work" — rewrite them as something provable. Fold functional, non-functional, and quality-gate requirements into concrete criteria below.
-
-```success-criteria
-GOAL: <one sentence describing the intended end state>
-
-SUCCESS CRITERIA:
-- <functional criterion> | verify: <shell command; exit 0 = pass>
-- <non-functional criterion, e.g. performance/security/accessibility> | verify: <shell command>
-- <quality gate, e.g. coverage threshold> | verify: <shell command>
-- <criterion only a human can check> | verify: manual <numbered human steps>
-
-NON-GOALS:
-- <explicitly out of scope>
-
-VERIFICATION COMMAND: <the non-manual verify commands above joined into one runnable command (e.g. with &&); exit 0 = all green>
-```
+Embed the machine-checkable block defined in [success-criteria.md](success-criteria.md), with the placeholders filled in. For an extensive plan, cover functional, non-functional, and quality-gate requirements as concrete criteria.
 
 ## Success Metrics
 

--- a/skills/shared/references/plan-templates/minimal.md
+++ b/skills/shared/references/plan-templates/minimal.md
@@ -10,20 +10,7 @@ date: YYYY-MM-DD
 
 ## Success Criteria
 
-Each criterion names the command that proves it. Use `verify: <command>` (exit 0 = pass) when a command can prove it without human judgment, or `verify: manual <steps>` when only a human can. Reject vacuous criteria like "make it work" — rewrite them as something provable.
-
-```success-criteria
-GOAL: <one sentence describing the intended end state>
-
-SUCCESS CRITERIA:
-- <observable criterion> | verify: <shell command; exit 0 = pass>
-- <observable criterion> | verify: manual <numbered human steps>
-
-NON-GOALS:
-- <explicitly out of scope>
-
-VERIFICATION COMMAND: <the non-manual verify commands above joined into one runnable command (e.g. with &&); exit 0 = all green>
-```
+Embed the machine-checkable block defined in [success-criteria.md](success-criteria.md), with the placeholders filled in.
 
 ## Context
 

--- a/skills/shared/references/plan-templates/minimal.md
+++ b/skills/shared/references/plan-templates/minimal.md
@@ -8,10 +8,22 @@ date: YYYY-MM-DD
 
 [Brief problem/feature description]
 
-## Acceptance Criteria
+## Success Criteria
 
-- [ ] Core requirement 1
-- [ ] Core requirement 2
+Each criterion names the command that proves it. Use `verify: <command>` (exit 0 = pass) when a command can prove it without human judgment, or `verify: manual <steps>` when only a human can. Reject vacuous criteria like "make it work" — rewrite them as something provable.
+
+```success-criteria
+GOAL: <one sentence describing the intended end state>
+
+SUCCESS CRITERIA:
+- <observable criterion> | verify: <shell command; exit 0 = pass>
+- <observable criterion> | verify: manual <numbered human steps>
+
+NON-GOALS:
+- <explicitly out of scope>
+
+VERIFICATION COMMAND: <the non-manual verify commands above joined into one runnable command (e.g. with &&); exit 0 = all green>
+```
 
 ## Context
 

--- a/skills/shared/references/plan-templates/standard.md
+++ b/skills/shared/references/plan-templates/standard.md
@@ -24,11 +24,22 @@ date: YYYY-MM-DD
 - Performance implications
 - Security considerations
 
-## Acceptance Criteria
+## Success Criteria
 
-- [ ] Detailed requirement 1
-- [ ] Detailed requirement 2
-- [ ] Testing requirements
+Each criterion names the command that proves it. Use `verify: <command>` (exit 0 = pass) when a command can prove it without human judgment, or `verify: manual <steps>` when only a human can. Reject vacuous criteria like "make it work" — rewrite them as something provable.
+
+```success-criteria
+GOAL: <one sentence describing the intended end state>
+
+SUCCESS CRITERIA:
+- <observable criterion> | verify: <shell command; exit 0 = pass>
+- <observable criterion> | verify: manual <numbered human steps>
+
+NON-GOALS:
+- <explicitly out of scope>
+
+VERIFICATION COMMAND: <the non-manual verify commands above joined into one runnable command (e.g. with &&); exit 0 = all green>
+```
 
 ## Success Metrics
 

--- a/skills/shared/references/plan-templates/standard.md
+++ b/skills/shared/references/plan-templates/standard.md
@@ -26,20 +26,7 @@ date: YYYY-MM-DD
 
 ## Success Criteria
 
-Each criterion names the command that proves it. Use `verify: <command>` (exit 0 = pass) when a command can prove it without human judgment, or `verify: manual <steps>` when only a human can. Reject vacuous criteria like "make it work" — rewrite them as something provable.
-
-```success-criteria
-GOAL: <one sentence describing the intended end state>
-
-SUCCESS CRITERIA:
-- <observable criterion> | verify: <shell command; exit 0 = pass>
-- <observable criterion> | verify: manual <numbered human steps>
-
-NON-GOALS:
-- <explicitly out of scope>
-
-VERIFICATION COMMAND: <the non-manual verify commands above joined into one runnable command (e.g. with &&); exit 0 = all green>
-```
+Embed the machine-checkable block defined in [success-criteria.md](success-criteria.md), with the placeholders filled in.
 
 ## Success Metrics
 

--- a/skills/shared/references/plan-templates/success-criteria.md
+++ b/skills/shared/references/plan-templates/success-criteria.md
@@ -1,0 +1,20 @@
+# Success Criteria block
+
+The single source for the machine-checkable success-criteria block. Every plan template and the `/plan` Success Criteria Gate reference this file so it is maintained once.
+
+Each criterion names the command that proves it. Use `verify: <command>` (exit 0 = pass) when a command can prove it without human judgment, or `verify: manual <steps>` when only a human can. Reject vacuous criteria like "make it work" — rewrite them as something provable. Fold functional, non-functional, and quality-gate requirements into concrete criteria.
+
+Embed this block verbatim in the plan's `## Success Criteria` section, filling in the placeholders:
+
+```success-criteria
+GOAL: <one sentence describing the intended end state>
+
+SUCCESS CRITERIA:
+- <observable criterion> | verify: <shell command; exit 0 = pass>
+- <observable criterion> | verify: manual <numbered human steps>
+
+NON-GOALS:
+- <explicitly out of scope>
+
+VERIFICATION COMMAND: <the non-manual verify commands above joined into one runnable command (e.g. with &&); exit 0 = all green>
+```


### PR DESCRIPTION
## Description

Adds a machine-checkable success-criteria gate to `/plan`.

- New **Success Criteria Gate** step: each criterion gets a `verify:` command (or `verify: manual <steps>`), and vacuous or subjective criteria are rejected and rewritten as something provable.
- Plan templates (minimal/standard/extensive) carry a fenced `success-criteria` block — `GOAL / SUCCESS CRITERIA / NON-GOALS / VERIFICATION COMMAND` — replacing the prose acceptance-criteria section. The block lives once in the shared templates; the per-skill `references/` symlinks are untouched.
- `/build` parse reference updated to read the new block.

Running the verify commands during a build is out of scope here and tracked in #204.

Closes #203.

## Type of Change

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)