### PR TITLE
feat(build): loop-until-verified ship gate for build and hotfix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,19 +76,21 @@ A `PreToolUse` hook runs on every `Read`, `Glob`, or `Grep` call. It detects the
 {
   "plugin": "plugin-name",
   "detect": { "file": "Gemfile", "pattern": "^\\s*gem\\s+['\"]rails['\"]" },
+  "verificationSkill": "plugin-name:green-gate",
   "marketplace": "OrgName/repo-name",
   "description": "What the plugin provides."
 }
 ```
 
-| Field             | Purpose                                                        |
-|-------------------|----------------------------------------------------------------|
-| `plugin`          | Plugin name as registered in the marketplace                   |
-| `detect.file`     | Exact file path whose presence signals the project type        |
-| `detect.files`    | Shell glob — greps inside every matching file for `pattern`    |
-| `detect.pattern`  | Regex grep pattern to confirm the match                        |
-| `marketplace`     | GitHub `owner/repo` for the marketplace registry               |
-| `description`     | One-line summary shown in the recommendation                   |
+| Field               | Purpose                                                        |
+|---------------------|----------------------------------------------------------------|
+| `plugin`            | Plugin name as registered in the marketplace                   |
+| `detect.file`       | Exact file path whose presence signals the project type        |
+| `detect.files`      | Shell glob — greps inside every matching file for `pattern`    |
+| `detect.pattern`    | Regex grep pattern to confirm the match                        |
+| `verificationSkill` | Optional. Skill the `/build` and `/hotfix` ship gate delegates to when this file's `detect` matches and the skill is installed |
+| `marketplace`       | GitHub `owner/repo` for the marketplace registry               |
+| `description`       | One-line summary shown in the recommendation                   |
 
 **Adding a new recommendation:** Drop a JSON file in `hooks/recommendations/` following the format above. No code changes required. All matching files are evaluated.
 

--- a/config/cspell.json
+++ b/config/cspell.json
@@ -22,7 +22,8 @@
     "worktrees",
     "undiscussed",
     "unrequested",
-    "pipefail"
+    "pipefail",
+    "runnable"
   ],
   "flagWords": []
 }

--- a/hooks/recommendations/very-good-ai-flutter-plugin.json
+++ b/hooks/recommendations/very-good-ai-flutter-plugin.json
@@ -5,6 +5,7 @@
     { "files": "docs/plan/*.md", "pattern": "flutter|dart" },
     { "files": "docs/brainstorm/*.md", "pattern": "flutter|dart" }
   ],
+  "verificationSkill": "very-good-ai-flutter-plugin:green-gate",
   "marketplace": "VeryGoodOpenSource/very_good_claude_code_marketplace",
   "description": "Dart and Flutter best-practice skills (accessibility, BLoC, testing, theming, navigation, security, i18n, architecture) and automated dart analyze/format hooks."
 }

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -23,7 +23,7 @@ Build Progress:
 - [ ] Phase 1: Read context files
 - [ ] Phase 2: Implement, test, and run the surgical-diff gate
 - [ ] Phase 3: Run review agents (5 in parallel)
-- [ ] Phase 4: Final validation, cleanup, and ship
+- [ ] Phase 4: Drive to green, cleanup, and ship
 ```
 
 ## Plan Input
@@ -128,11 +128,18 @@ Follow the [review consolidation procedure](references/review-consolidation.md):
 
 ## Phase 4 — Ship
 
-### Final Validation
+### Drive to green
 
-Run the full suite one last time — detect and use the project's formatter, linter, and test runner.
+The plan's `success-criteria` block is the ship gate. Parse it, then handle these cases before looping:
 
-If anything fails, fix it before proceeding.
+| Case | Action |
+| ---- | ------ |
+| Block present with a `VERIFICATION COMMAND` | Gate set = the non-manual `verify:` commands; authoritative command = the `VERIFICATION COMMAND`. |
+| Block present, `VERIFICATION COMMAND` missing but non-manual `verify:` lines exist | Synthesize the authoritative command by joining those `verify:` commands with `&&`. |
+| Only `verify: manual` criteria, no runnable command | Skip the loop; go straight to the manual-criteria checklist. Never treat an empty runnable set as green. |
+| No `success-criteria` block (plan predates it) | Fall back to the detected project suite (formatter, linter, test runner) as the gate, and warn the user the plan has no machine-checkable criteria. Never treat an absent block as green. |
+
+Then follow the [drive to green procedure](references/drive-to-green.md) with that gate set and authoritative command. It loops until every gate is green by real output, delegates to a matching installed verification skill when one exists, runs the authoritative command as the final check, and escalates only on un-runnable or self-contradictory criteria. Do not proceed to cleanup until the authoritative gate is green and any manual criteria are confirmed.
 
 ### Cleanup
 

--- a/skills/build/references/drive-to-green.md
+++ b/skills/build/references/drive-to-green.md
@@ -1,0 +1,1 @@
+../../shared/references/drive-to-green.md

--- a/skills/hotfix/SKILL.md
+++ b/skills/hotfix/SKILL.md
@@ -121,9 +121,9 @@ rm -rf docs/hotfix-review/
 
 ## Phase 5 — Ship
 
-### Final Validation
+### Drive to green
 
-Run the project's formatter, linter, and test runner one last time. Fix any failures before proceeding.
+A hotfix has no plan, so there is no `success-criteria` block. Follow the [drive to green procedure](references/drive-to-green.md) with the detected project suite (formatter, linter, test runner) as both the gate set and the authoritative command run once. It loops until green by real output, delegates to a matching installed verification skill when one exists, and escalates only on un-runnable or self-contradictory failures — never on an ordinary, fixable one. Do not proceed until it is green.
 
 ### Ship
 

--- a/skills/hotfix/references/drive-to-green.md
+++ b/skills/hotfix/references/drive-to-green.md
@@ -1,0 +1,1 @@
+../../shared/references/drive-to-green.md

--- a/skills/shared/references/drive-to-green.md
+++ b/skills/shared/references/drive-to-green.md
@@ -1,0 +1,60 @@
+# Drive to Green
+
+The authoritative ship gate for `/build` and `/hotfix`. Loop until every gate is green by real output, then prove it with one authoritative command. Delegate the loop to a companion verification skill when the project has one installed; otherwise run the loop generically. Escalate only when a criterion is un-runnable or self-contradictory — never on an ordinary, fixable failure.
+
+## Inputs
+
+The calling skill supplies two things:
+
+- **Gate set** — the commands that must each exit 0.
+  - `/build`: the non-manual `verify:` commands from the plan's `success-criteria` block.
+  - `/hotfix`: the project's detected formatter, linter, and test runner (no plan, so no `verify:` commands).
+- **Authoritative command** — the single command that proves the whole gate set is green.
+  - `/build`: the plan's `VERIFICATION COMMAND`.
+  - `/hotfix`: the detected suite run once.
+
+The driver that follows is a best-effort accelerator to reach green. The **authoritative command is the source of truth** — it runs unconditionally after the driver, so a driver that stops while still red is caught here rather than shipped.
+
+## Step 1 — Select the driver
+
+Read the plugin's `hooks/recommendations/*.json`. A file participates only if it carries a `verificationSkill` field. For each such file, evaluate its `detect` rule against the current project — the same file/glob + case-insensitive regex OR-logic the `recommend-plugins.sh` hook applies (it greps with `-iE`).
+
+| Condition | Action |
+| --------- | ------ |
+| `detect` matches **and** the named skill is available | **Delegate** — invoke the skill named in that file's `verificationSkill` field to drive the package to green. |
+| `detect` matches but the skill is **not** installed | Surface its install recommendation once, then use the **generic loop**. |
+| No `detect` matches | Use the **generic loop**. |
+
+If more than one file matches, first match wins. Prefer the project's MCP analyzer and test tools over shell commands when they are available.
+
+## Step 2 — Drive to green
+
+- **Delegated** — invoke the companion skill and let it run its own verify-fix-rerun loop. Do not wrap it in a second loop of your own.
+- **Generic** — run each gate-set command. On a non-zero exit, fix the root cause and re-run that command. Repeat until it exits 0. Fix objective failures (red tests, lint errors, coverage gaps) autonomously — do not re-prompt the user for them.
+
+## Step 3 — Authoritative gate
+
+Run the authoritative command **once**, after the driver, regardless of which driver ran.
+
+- Exit 0 → the gate is green. Proceed to manual criteria (Step 5).
+- Non-zero → re-enter Step 2, fixing against **this command's** actual output. The authoritative command wins any disagreement with an individual gate-set command.
+
+## Step 4 — Escalation
+
+Objective, fixable failures are never escalated — fix and re-run. Stop and ask the user with **AskUserQuestion** only when:
+
+| Trigger | Detection |
+| ------- | --------- |
+| **Un-runnable** | `command not found` / exit 127 / a missing tool, dependency, or codegen step / infrastructure failure |
+| **No progress** | The failure fingerprint is identical to the prior round, or the failure count did not decrease |
+| **Oscillation** | Two gates trade green and red across consecutive rounds |
+| **Ceiling reached** | Total Step 2 to Step 3 re-entries reach 5 with gates still red |
+| **Criteria disagree with the gate** | Every gate-set command passes but the authoritative command stays red across rounds — the plan is internally inconsistent |
+
+A failure **fingerprint** is the sorted set of `failing command + error signature` for the round; without it, "no progress" is undecidable. Exactly one driver owns escalation per run: if a delegated skill escalates, surface its reason and stop — do not re-invoke it.
+
+When escalating, report the failing command, its output, the rounds attempted, and the specific decision the user must make.
+
+## Step 5 — Manual criteria (`/build` only)
+
+`verify: manual <steps>` criteria cannot be auto-run. Once the authoritative gate is green, present them with **AskUserQuestion** as a checklist and ship only on explicit confirmation. Record the confirmation in the PR body so it is auditable. A plan with only manual criteria skips Steps 2 and 3 and goes straight here — never treat an empty runnable set as green.


### PR DESCRIPTION
## Description

Replaces the run-once ship step in `/build` Phase 4 and `/hotfix` Phase 5 with a loop-until-green gate. Re-run each success criterion's `verify:` command until it's green by real output, then run the plan's `VERIFICATION COMMAND` as the unconditional authoritative check before shipping. When the project matches a companion verification skill and it's installed, the loop delegates to it (via a new `verificationSkill` field on the recommendation registry); otherwise it falls back to a generic loop. Escalation replaces the old 3-attempt cap: it only prompts on un-runnable or self-contradictory criteria, never on ordinary fixable failures.

The drive-to-green procedure is shared between both ship phases as a single canonical reference, symlinked into each skill (same pattern as `validate-and-fix.md`).

Closes #204. Depends on #203.

## Type of Change

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)