### PR TITLE
ci: tag dependabot and release-please PRs with no-auto-update

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "no-auto-update"

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -11,6 +11,7 @@
   ],
   "pull-request-header": ":rotating_light: There are changes ready for release :rocket:\n\nℹ Merge this PR once the team confirms the release is ready.\n",
   "pull-request-title-pattern": "chore: ${version}",
+  "extra-label": "no-auto-update",
   "include-component-in-tag": false,
   "packages": {
     ".": {


### PR DESCRIPTION
## Description

Configures the repository so every Dependabot and release-please PR is labeled `no-auto-update`. Per [vgv-ai-bot GETTING_STARTED.md](https://github.com/VGVentures/vgv-ai-bot/blob/main/GETTING_STARTED.md), that label is the per-PR escape hatch for the bot's **Auto-update PRs** feature. Labeled PRs are skipped when the base branch moves, so bot-generated PRs won't be churned by auto-update.

**Changes**

- **`.github/dependabot.yaml`** — add `labels: [dependencies, no-auto-update]`. Dependabot's `labels` key *overrides* its defaults, so `dependencies` is listed explicitly to preserve it. (`github_actions` intentionally omitted — Dependabot only auto-adds the ecosystem label when multiple ecosystems are configured; with a single ecosystem it's redundant.)
- **`.release-please-config.json`** — add `"extra-label": "no-auto-update"`. Unlike `label`, `extra-label` *appends* to the default `autorelease: pending` rather than overriding it, so release-please's own bookkeeping label is preserved.
- **Repository label** — created the `no-auto-update` label (Dependabot only applies custom labels that already exist; it does not create them).

## Reviewer notes

- Auto-update PRs is dashboard-controlled and off by default. This label is inert until an admin enables that feature per-repo/org — harmless until then.
- `extra-label` is a release-please schema key (comma-separated string); `labels` is **not** in the release-please schema and would be silently ignored.

## Type of Change

- [ ] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [x] CI change (`ci`)
- [ ] Chore (`chore`)
