### PR TITLE
feat(plan): merge plan-technical-review into /plan and split work into phases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ Technology-specific concerns (linting, formatting, scaffolding, framework conven
 The plugin supports three sequential phases:
 
 1. **`/brainstorm`** — Explore requirements and approaches through collaborative dialogue. Produces a brainstorm document.
-2. **`/plan`** — Transform brainstorm output into an actionable implementation plan. Includes codebase review, optional external research, and flow analysis.
-3. **`/build`** — Execute implementation plans: write code and tests, run quality review, and ship a pull request.
+2. **`/plan`** — Transform brainstorm output into an actionable implementation plan. Includes codebase review, optional external research, flow analysis, and a mandatory quality review of the draft. Splits large plans into phases so `/build` executes one phase per context window.
+3. **`/build`** — Execute implementation plans: implement one phase per context window (implement → validate → commit → checkpoint → clear), run quality review, and ship a pull request. Committing and pushing follow the user's chosen autonomy — per-phase auto-commits or full manual control — decided up front or from a saved preference.
 
 Standalone Skills:
 
@@ -36,7 +36,7 @@ Supporting skills:
 
 - `/create` (project creation — routes to companion plugins)
 - `/create-pr` (generate a PR title and description from branch commits and optionally open it on GitHub or GitLab)
-- `/plan-technical-review` (validate plans)
+- `/plan-technical-review` (review externally-authored plans; `/plan` reviews the plans it creates inline)
 - `/refine-approach` (iterative document improvement)
 - `/rebase` (sync feature branch with base branch)
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Once you're happy with the brainstorm, turn it into an actionable implementation
 /plan add email/password and OAuth login using the auth approach from our brainstorm
 ```
 
-This reviews your codebase, references the brainstorm, and produces a step-by-step plan saved to `docs/plan/`.
+This reviews your codebase, references the brainstorm, runs a mandatory quality pass on the draft, and produces a phased, step-by-step plan saved to `docs/plan/`. Large plans are split into phases so `/build` can execute one phase per context window.
 
 ### 3. `/build`
 
@@ -93,8 +93,8 @@ Wingspan operates at a higher level, orchestrating agentic workflows across the 
 |-------|---------|-------------|
 | [**Brainstorm**](skills/brainstorm/SKILL.md) | `/brainstorm <feature or idea>` | Explore requirements and approaches through collaborative dialogue |
 | [**Refine Approach**](skills/refine-approach/SKILL.md) | `/refine-approach` | Review and refine brainstorms or plans before proceeding |
-| [**Plan**](skills/plan/SKILL.md) | `/plan <feature, bug fix, or improvement>` | Transform brainstorm output into a structured implementation plan |
-| [**Plan Technical Review**](skills/plan-technical-review/SKILL.md) | `/plan-technical-review` | Validate that a plan meets requirements and follows best practices |
+| [**Plan**](skills/plan/SKILL.md) | `/plan <feature, bug fix, or improvement>` | Transform brainstorm output into a reviewed, phased implementation plan |
+| [**Plan Technical Review**](skills/plan-technical-review/SKILL.md) | `/plan-technical-review <plan path>` | Review an externally-authored plan — plans from `/plan` are already reviewed during creation |
 | [**Build**](skills/build/SKILL.md) | `/build <plan file path>` | Execute a plan — write code and tests, run quality review, ship a PR |
 | [**Review**](skills/review/SKILL.md) | `/review [path]` | Run quality review agents on demand — assess code quality and identify issues |
 | [**Hotfix**](skills/hotfix/SKILL.md) | `/hotfix <bug description>` | Apply a minimal, targeted fix for emergency bugs — enforces review and testing without brainstorm or planning |

--- a/agents/analysis/plan-splitting-agent.md
+++ b/agents/analysis/plan-splitting-agent.md
@@ -1,7 +1,7 @@
 ---
 name: plan-splitting-agent
 description: |
-  Analyzes implementation plans for scope and recommends splitting large plans into multiple independently-mergeable PRs. Use during plan technical review to catch oversized plans before development begins.
+  Analyzes implementation plans for scope and recommends splitting large plans into multiple independently-mergeable PRs. Use during plan creation and technical review to catch oversized plans before development begins.
 
   <examples>
     <example>

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -47,12 +47,12 @@ Do not proceed without a plan.
 
 **After loading the plan:** parse title, type, the `success-criteria` block, tasks, file paths, and the `## Implementation Phases` section if present.
 
-**Commit autonomy:** decide once how this build commits, and carry the choice through the whole run. Honor a stated user preference (Claude memory or a CLAUDE.md instruction) if one exists; otherwise use **AskUserQuestion**:
+**Commit autonomy:** decide once how this build commits, and carry the choice through the whole run. Honor a saved preference if one exists (Claude memory or the user's personal settings); otherwise use **AskUserQuestion**:
 
 - **Auto-commit each phase (Recommended)**: commit automatically as each phase completes. Pushing and opening the PR still pause for approval (Phase 4).
 - **I'll commit myself**: build one phase, then stop so the user reviews and commits. Nothing is committed or pushed without the user.
 
-Offer to save the choice (memory or CLAUDE.md) so future builds skip this question.
+Offer to save the choice to Claude memory (a personal preference) so future builds skip this question. Save it as the user's own preference — never write it to the project's CLAUDE.md, since committing this is a per-developer choice, not a repo convention.
 
 **Resuming a phased build:** if the plan has an `## Implementation Phases` section with at least one phase already marked `**Status:** Done`, this is a resumed build. Announce "Resuming at Phase N: [name]" — the first phase whose status is not `Done` — and go straight to Phase 1 for that phase. Skip the scope-confirmation question below.
 
@@ -219,11 +219,11 @@ cite `FINDING-NN` ids (there would be no report left to map them to).
 
 Whatever commits this build produced are local. Pushing and opening a PR is outward-facing, so gate it on the user's preference — separately from the commit-autonomy choice:
 
-- **User has a stated preference to push automatically** (in Claude's memory or a CLAUDE.md instruction) → push and open the PR without asking.
+- **User has a saved preference to push automatically** (Claude memory or personal settings) → push and open the PR without asking.
 - **No such preference** → use **AskUserQuestion** before anything leaves the machine:
   1. **Review locally first (Recommended)**: stop here. The commits stay local; the user pushes and opens the PR when ready. Do not call `/create-pr`.
   2. **Push and open the PR now**: proceed this once.
-  3. **Always push automatically**: proceed, and save the preference (to memory or a CLAUDE.md instruction) so future builds skip this prompt.
+  3. **Always push automatically**: proceed, and save the preference to Claude memory (the user's own preference, never the project's CLAUDE.md) so future builds skip this prompt.
 
 To push, call `/create-pr skip-checks` — it pushes and opens the PR. Validation already ran above. The PR body uses the [PR template](references/pr-template.md).
 

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -19,9 +19,9 @@ Copy this checklist and track your progress:
 
 ```markdown
 Build Progress:
-- [ ] Phase 0: Load plan and confirm scope
-- [ ] Phase 1: Read context files
-- [ ] Phase 2: Implement, test, and run the surgical-diff gate
+- [ ] Phase 0: Load plan and confirm scope (or resume a phased build)
+- [ ] Phase 1: Read context for the current implementation phase
+- [ ] Phase 2: Loop implementation phases (implement → validate → commit or hand off → checkpoint → clear)
 - [ ] Phase 3: Run review agents (5 in parallel), consolidate into one report
 - [ ] Phase 4: Drive to green, cleanup, and ship
 ```
@@ -45,7 +45,18 @@ ls docs/plan/
 
 Do not proceed without a plan.
 
-**After loading the plan:** parse title, type, the `success-criteria` block, tasks, and file paths. Summarize scope to the user, then use **AskUserQuestion** to confirm:
+**After loading the plan:** parse title, type, the `success-criteria` block, tasks, file paths, and the `## Implementation Phases` section if present.
+
+**Commit autonomy:** decide once how this build commits, and carry the choice through the whole run. Honor a stated user preference (Claude memory or a CLAUDE.md instruction) if one exists; otherwise use **AskUserQuestion**:
+
+- **Auto-commit each phase (Recommended)**: commit automatically as each phase completes. Pushing and opening the PR still pause for approval (Phase 4).
+- **I'll commit myself**: build one phase, then stop so the user reviews and commits. Nothing is committed or pushed without the user.
+
+Offer to save the choice (memory or CLAUDE.md) so future builds skip this question.
+
+**Resuming a phased build:** if the plan has an `## Implementation Phases` section with at least one phase already marked `**Status:** Done`, this is a resumed build. Announce "Resuming at Phase N: [name]" — the first phase whose status is not `Done` — and go straight to Phase 1 for that phase. Skip the scope-confirmation question below.
+
+**Otherwise**, summarize scope to the user, then use **AskUserQuestion** to confirm:
 
 - **Start building (Recommended)**: proceed with implementation
 - **Review the plan first**: open the plan file for review
@@ -59,19 +70,26 @@ Do not proceed until the user selects "Start building."
 
 Instead, use the plan itself as your guide:
 
-1. **Read referenced files**: Read every file listed in the plan's tasks (files to create or modify) plus their immediate neighbors (e.g., sibling files in the same directory) for implementation context.
+1. **Read referenced files**: Read the files for the phase you are about to build (the current phase's **Files touched**, plus their immediate neighbors). For a plan with no `## Implementation Phases` section, read every file listed in the plan's tasks. Reading only the current phase's files keeps context focused so each phase fits in one window.
 2. **Extract conventions**: If the plan includes a codebase context or conventions section, use it as your source of truth for patterns and style.
 3. **Targeted searches only**: If the plan references a pattern or convention you need a concrete example of, use Grep or Glob to find a single representative example — do not do a broad sweep.
 
 ## Phase 2 — Execute
 
-Work through each task/phase in the plan, in order. For each task:
+Determine the unit of work:
 
-### Step 1: Implement
+- **Plan has an `## Implementation Phases` section** → build one phase at a time with the phase loop below. Each phase carries the fields defined in the [implementation phases block](references/implementation-phases.md) — Status, Scope, Files touched, Acceptance criteria, and Validation — and is sized to fit a single context window, so `/build` executes one phase per window.
+- **No phases** → treat the whole plan as one phase: implement every task, then run the loop once.
 
-Write code following VGV conventions. Build layers in dependency order (Data → Domain → Presentation). Use the project's state management tool, naming patterns, linter, and formatter. Respect layer boundaries — presentation never imports data directly.
+### Phase loop
 
-### Step 2: Test
+Pick the current phase — the first whose `**Status:**` is not `Done` (a plan with no phases has one implicit phase: the whole plan). Run these steps for it:
+
+#### Step 1: Implement
+
+Write code following VGV conventions, limited to this phase's **Scope** and **Files touched**. Build layers in dependency order (Data → Domain → Presentation). Use the project's state management tool, naming patterns, linter, and formatter. Respect layer boundaries — presentation never imports data directly.
+
+#### Step 2: Test
 
 Tests are non-negotiable. Write them alongside each implementation unit:
 
@@ -82,31 +100,58 @@ Tests are non-negotiable. Write them alongside each implementation unit:
 
 Every new state management unit, repository, UI component, and data model must have a test file.
 
-### Step 3: Validate
+#### Step 3: Validate
 
-After implementing each task, follow the [validation and fix procedure](references/validate-and-fix.md).
+Run the phase's **Validation** steps, then follow the [validation and fix procedure](references/validate-and-fix.md). Everything must pass before you record the phase.
 
-### Step 4: Checkpoint
+#### Step 4: Record the phase
 
-After each logical unit of work:
+Set this phase's `**Status:**` to `Done` in the plan file — this marker lets a build resume the right phase after a context clear (the plan is a local artifact, so it survives `/clear`).
 
-1. Brief progress update to the user: what was completed, what's next.
+Then handle the phase's changes per the **commit autonomy** chosen in Phase 0:
+
+- **Auto-commit each phase** → stage and commit the phase now, using the format below.
+- **I'll commit myself** → do not commit. Summarize the phase's changed files and leave them staged for the user to review.
+
+Auto-commit message format:
+
+```text
+<type>: <phase name>
+
+<one-line summary of what the phase delivered>
+```
+
+`<type>` matches the plan's type (`feat`, `fix`, `refactor`, …). One commit per phase keeps the branch history clean and each phase independently reviewable. A single-phase plan produces one implementation commit here.
+
+#### Step 5: Checkpoint
+
+Brief progress update to the user: phase completed, phases remaining.
+
+#### Step 6: Advance
+
+- **More phases remain, auto-commit mode** → use **AskUserQuestion**:
+  1. **Clear context and continue (Recommended)**: build the next phase in a fresh window. Follow the [clear context handoff](references/clear-context-handoff.md) with `<NEXT_SKILL>` = `build`, `<DOC_PATH>` = this plan's path, and `<NEXT_ACTION>` = "the next phase". Then **stop**.
+  2. **Continue in this context**: loop back and build the next phase now.
+  3. **Stop here**: end the session; the plan's `**Status:**` markers record which phases remain.
+- **More phases remain, I'll-commit-myself mode** → **stop**. Tell the user the phase is ready to review and commit, then to run `/build` on this plan again to continue with the next phase (it resumes from the `**Status:**` markers).
+- **No phases remain** (last phase done, or the plan had none) → proceed to the Surgical-Diff Gate.
 
 ### Execution Rules
 
-- Follow the plan's task order. Don't skip ahead.
+- Follow the plan's phase and task order. Don't skip ahead.
+- Build only the current phase. Do not pull work forward from a later phase.
 - Never skip tests. Every testable unit gets a test file.
 - Never add features not in the plan (YAGNI).
 - Ask the user only when genuinely stuck: ambiguous architecture decision, 3 failed fix attempts, or a missing dependency not mentioned in the plan.
-- If a task in the plan is unclear, re-read the plan and the relevant codebase context before asking the user.
+- If a phase or task is unclear, re-read the plan and the relevant codebase context before asking the user.
 
 ### Surgical-Diff Gate
 
-Once every task is implemented, tested, and validated, follow the [surgical-diff gate](references/surgical-diff-gate.md) before moving to review: diff the whole branch against its merge-base, remove untraceable churn, delete only self-created orphans, and collect a "Noticed (not changed):" note for pre-existing dead code. Running it here keeps the review phase focused on the diff that belongs, not churn that would be reverted anyway.
+Once the final phase is committed, follow the [surgical-diff gate](references/surgical-diff-gate.md) before moving to review: diff the whole branch against its merge-base, remove untraceable churn, delete only self-created orphans, and collect a "Noticed (not changed):" note for pre-existing dead code. Commit any cleanup it produces. Running it here keeps the review phase focused on the diff that belongs, not churn that would be reverted anyway.
 
 ## Phase 3 — Quality Review
 
-After all implementation tasks are complete, run 5 review agents **in parallel**.
+Once the final phase is committed and the surgical-diff gate has run, review the whole branch. Run 5 review agents **in parallel** — they review the full branch diff, so this runs once after the last phase, not per phase.
 
 ### Agent instructions
 
@@ -155,21 +200,32 @@ rm -rf docs/reviews/
 
 ### Commit
 
-Stage all implementation and fix changes. Use this commit format:
+Handle the outstanding changes — the drive-to-green loop, the surgical-diff gate, and the Phase 3 review fixes — per the **commit autonomy** chosen in Phase 0:
+
+- **Auto-commit mode** → the phases are already committed from Phase 2; stage and commit whatever is still outstanding, using the format below. If nothing is outstanding, skip this commit.
+- **I'll-commit-myself mode** → do not commit. Summarize everything still uncommitted and leave it staged for the user.
 
 ```text
-<type>: <concise description of what was built>
+<type>: address review findings
 
-Implements <plan title or summary>.
+<one-line summary of the fixes>
 ```
 
-Where `<type>` matches the plan's type (`feat`, `fix`, `refactor`, etc.). Review findings are
-fixed in place during Phase 3 and the report is deleted at Cleanup, so the commit does not
+`<type>` matches the plan's type (`feat`, `fix`, `refactor`, etc.). Either way, review findings
+are fixed in place during Phase 3 and the report is deleted at Cleanup, so any commit does not
 cite `FINDING-NN` ids (there would be no report left to map them to).
 
 ### Ship
 
-Call `/create-pr skip-checks` to push and open a PR. Validation already ran above. The PR body uses the [PR template](references/pr-template.md).
+Whatever commits this build produced are local. Pushing and opening a PR is outward-facing, so gate it on the user's preference — separately from the commit-autonomy choice:
+
+- **User has a stated preference to push automatically** (in Claude's memory or a CLAUDE.md instruction) → push and open the PR without asking.
+- **No such preference** → use **AskUserQuestion** before anything leaves the machine:
+  1. **Review locally first (Recommended)**: stop here. The commits stay local; the user pushes and opens the PR when ready. Do not call `/create-pr`.
+  2. **Push and open the PR now**: proceed this once.
+  3. **Always push automatically**: proceed, and save the preference (to memory or a CLAUDE.md instruction) so future builds skip this prompt.
+
+To push, call `/create-pr skip-checks` — it pushes and opens the PR. Validation already ran above. The PR body uses the [PR template](references/pr-template.md).
 
 ### Post-Ship
 

--- a/skills/build/references/clear-context-handoff.md
+++ b/skills/build/references/clear-context-handoff.md
@@ -1,0 +1,1 @@
+../../shared/references/clear-context-handoff.md

--- a/skills/build/references/implementation-phases.md
+++ b/skills/build/references/implementation-phases.md
@@ -1,0 +1,1 @@
+../../shared/references/plan-templates/implementation-phases.md

--- a/skills/plan-technical-review/SKILL.md
+++ b/skills/plan-technical-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: plan-technical-review
 user-invocable: true
-description: Conducts a comprehensive technical review of an implementation plan, ensuring it meets requirements and follows best practices.
-when_to_use: Use when user says "review the plan", "is this plan ready", "validate my plan", or "check the plan".
+description: Reviews an externally-authored implementation plan for quality, VGV conventions, and scope. Plans created by /plan are already reviewed during creation.
+when_to_use: Use to review a plan you did not create with /plan — a hand-written plan or one from another tool. Triggers on "review the plan", "is this plan ready", "validate my plan", or "check the plan".
 argument-hint: path to plan file
 effort: high
 compatibility: Designed for Claude Code (or similar products with agent support)
@@ -10,32 +10,21 @@ compatibility: Designed for Claude Code (or similar products with agent support)
 
 # Plan technical review
 
+Review a plan that was not created by `/plan`. `/plan` runs this same review inline during
+creation, so use this skill for externally-authored plans — hand-written, from another tool,
+or from a teammate.
+
 **Plan file:** `$ARGUMENTS` (if empty, ask the user for the plan path or pick the most recent file under `docs/plan/`).
 
-Run the following agents in parallel to conduct a comprehensive technical review of the plan at `$ARGUMENTS`. Pass the plan path to each agent:
+## Review
 
-- @code-simplicity-review-agent: Review the plan for simplicity and clarity. Ensure the implementation is as straightforward as possible while still meeting all requirements.
-- @vgv-review-agent: Review the plan for adherence to Very Good Engineering practices and project conventions. Ensure the implementation follows our established patterns and conventions.
-- @plan-splitting-agent: Assess plan scope and recommend splitting into multiple PRs if the plan is too large for a single reviewable PR.
-
-After all agents complete, if the plan-splitting-agent recommends a split:
-
-1. Present the proposal to the developer via **AskUserQuestion** with options:
-   - **Apply this split**: generate separate plan files
-   - **Keep as single PR**: proceed without splitting
-2. If approved, generate separate plan files:
-   - The **skill** (not the agent) generates the files
-   - Naming: `docs/plan/YYYY-MM-DD-<type>-<original-slug>-part-N-plan.md`
-   - Each file is a standalone plan following the **same template and detail level** as the original plan
-   - Each file includes all sections `/build` expects: title, type, acceptance criteria, tasks, file references. Use [standard template](references/standard.md) by default; use [minimal](references/minimal.md) for simple parts or [extensive](references/extensive.md) for complex parts.
-   - Each file includes a `## Dependencies` section noting which prior PR(s) must merge first
-   - Add a note at the top of the original plan file: ``> **Note:** This plan has been split into parts. See the `-part-N` files in this directory.``
-
-If the plan-splitting-agent reports no split needed: include the scope summary in the review output, no further action.
+Follow the [plan review procedure](references/plan-review.md) with `<PLAN_PATH>` set to the
+plan file. It runs the simplicity, VGV, and scope-splitting agents in parallel, applies their
+findings to the plan inline, and resolves any scope-splitting recommendation.
 
 ## Handoff
 
-**When invoked directly by the user**, use **AskUserQuestion** to present next steps after the review is complete:
+After the review completes, use **AskUserQuestion** to present next steps:
 
 **Question**: "Technical review complete! What would you like to do next?"
 
@@ -48,4 +37,4 @@ If the plan-splitting-agent reports no split needed: include the scope summary i
 
 **If the user selects "Clear context and build"** → Follow the [clear context handoff](references/clear-context-handoff.md) for `/build` with the actual plan file path. Then stop.
 
-**When invoked by another skill** (e.g., from `/plan`), return control to the caller after the review completes — do not present handoff options.
+**When invoked by another skill**, return control to the caller after the review completes — do not present handoff options.

--- a/skills/plan-technical-review/references/extensive.md
+++ b/skills/plan-technical-review/references/extensive.md
@@ -1,1 +1,0 @@
-../../shared/references/plan-templates/extensive.md

--- a/skills/plan-technical-review/references/minimal.md
+++ b/skills/plan-technical-review/references/minimal.md
@@ -1,1 +1,0 @@
-../../shared/references/plan-templates/minimal.md

--- a/skills/plan-technical-review/references/plan-review.md
+++ b/skills/plan-technical-review/references/plan-review.md
@@ -1,0 +1,1 @@
+../../shared/references/plan-review.md

--- a/skills/plan-technical-review/references/standard.md
+++ b/skills/plan-technical-review/references/standard.md
@@ -1,1 +1,0 @@
-../../shared/references/plan-templates/standard.md

--- a/skills/plan-technical-review/references/success-criteria.md
+++ b/skills/plan-technical-review/references/success-criteria.md
@@ -1,1 +1,0 @@
-../../shared/references/plan-templates/success-criteria.md

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -185,17 +185,25 @@ Examples:
 - ❌ `docs/plan/2026-01-15-feat-thing-plan.md` (not descriptive)
 - ❌ `docs/plan/feat-user-auth-plan.md` (missing date prefix)
 
+## Plan Review
+
+After writing the plan file and before presenting options, run a mandatory quality pass on it. This replaces the separate `/plan-technical-review` step — plans created here are reviewed here.
+
+- **Minimal template** → skip this section. The overhead is not worth it for a small plan.
+- **Standard or Extensive template** → follow the [plan review procedure](references/plan-review.md) with `<PLAN_PATH>` set to the plan file. It runs the simplicity, VGV, and scope-splitting agents in parallel, applies their findings to the plan inline, and — if the plan is too large for one PR — offers to restructure the work into phases or split it into part-N files.
+
+Return here once the review completes, then present the options below.
+
 ## Post-Generation Options
 
-After writing the plan file, use the **AskUserQuestion tool** and present the following options:
+After the review completes, use the **AskUserQuestion tool** and present the following options:
 
 **Options:**
 
 1. **Clear context and build (Recommended)**: clear context for a fresh start, then build
 2. **Start building**: execute this plan with `/build`
 3. **Open the plan file in my code editor**: open the plan file for review
-4. **Run `/plan-technical-review` on this plan**: run the technical review skill to validate the plan
-5. **Review and refine**: improve the plan through self-review
+4. **Review and refine**: improve the plan through self-review
 
 **If the user selects "Clear context and build"** → Follow the [clear context handoff](references/clear-context-handoff.md) for `/build` with the actual plan file path. Then stop.
 
@@ -203,7 +211,6 @@ After writing the plan file, use the **AskUserQuestion tool** and present the fo
 
 - **Start building** → Call the `/build` skill with the plan file path
 - **Open plan in editor** → Run `open docs/plan/<plan_filename>.md` to open the file in the user's default editor
-- **`/plan-technical-review`** → Call the `/plan-technical-review` skill with the plan file path
 - **Review and refine** → Load `/refine-approach` skill.
 - **Other** (automatically provided) → Accept free text for rework or specific changes
 

--- a/skills/plan/references/implementation-phases.md
+++ b/skills/plan/references/implementation-phases.md
@@ -1,0 +1,1 @@
+../../shared/references/plan-templates/implementation-phases.md

--- a/skills/plan/references/plan-review.md
+++ b/skills/plan/references/plan-review.md
@@ -1,0 +1,1 @@
+../../shared/references/plan-review.md

--- a/skills/shared/references/plan-review.md
+++ b/skills/shared/references/plan-review.md
@@ -1,0 +1,64 @@
+# Plan Review
+
+Runs the plan-quality agents against a written plan, applies their findings to the plan
+inline, and resolves any scope-splitting recommendation. This is the single procedure shared
+by `/plan` (a mandatory step for standard and extensive plans) and `/plan-technical-review`
+(the entry point for externally-authored plans).
+
+`<PLAN_PATH>` is the plan file under review.
+
+## 1. Run the review agents in parallel
+
+Pass `<PLAN_PATH>` to each. Run all three concurrently:
+
+- **@code-simplicity-review-agent** — review the plan for simplicity and clarity; the implementation should be as straightforward as possible while still meeting every requirement.
+- **@vgv-review-agent** — review the plan for adherence to Very Good Engineering practices and project conventions.
+- **@plan-splitting-agent** — assess plan scope and report whether the work is too large for a single reviewable PR.
+
+## 2. Apply findings inline
+
+Fold the simplicity and VGV findings into the plan file directly — tighten scope, close
+convention gaps, remove speculative work. Edit `<PLAN_PATH>` in place. The reader should see
+the improved plan, not a list of findings to reconcile.
+
+## 3. Resolve the scope assessment
+
+| plan-splitting-agent result | Action |
+|-----------------------------|--------|
+| No split needed | Keep the plan single-phase. Record the one-line scope summary. Done. |
+| Split recommended | Use **AskUserQuestion** to choose how to act (below). |
+
+When a split is recommended, present these options:
+
+1. **Restructure into phases in one plan (Recommended)** — keep a single plan file and add an `## Implementation Phases` section whose phases follow the proposed split boundaries.
+2. **Split into separate part-N files** — generate one standalone plan file per proposed PR.
+3. **Keep as one plan, no phases** — proceed unchanged; the developer accepts a larger PR.
+
+### Restructure into phases
+
+Add an `## Implementation Phases` section to `<PLAN_PATH>`. Map each proposed split boundary
+to one phase, ordered so every phase leaves the codebase compiling with its tests passing.
+For each phase, write one `### Phase N: <name>` with these fields, matching the block the plan
+template defines:
+
+- **Status:** `Not started`
+- **Scope:** 1-2 sentences
+- **Files touched:** the paths this phase creates or modifies
+- **Acceptance criteria:** observable proof the phase is complete
+- **Validation:** a command (exit 0 = pass) or `manual <numbered steps>`
+
+Size each phase to fit comfortably in one AI context window. Do not create additional files.
+
+### Split into separate part-N files
+
+The **skill**, not the agent, writes the files:
+
+- Naming: `docs/plan/YYYY-MM-DD-<type>-<original-slug>-part-N-plan.md`
+- Each part is a standalone plan at the same detail level as the original, with every section `/build` expects: title, type, success criteria, tasks, and file references.
+- Each part includes a `## Dependencies` section naming the prior part(s) that must merge first.
+- Add a note to the top of the original plan: `> **Note:** This plan was split into parts. See the -part-N files in this directory.`
+
+## Caller responsibilities
+
+- **`/plan`** invokes this after writing the draft and before presenting post-generation options. Skip it entirely for the `minimal` template. Do not present handoff options here — return to the plan flow.
+- **`/plan-technical-review`** invokes this on a user-supplied plan, then presents its own handoff options.

--- a/skills/shared/references/plan-templates/extensive.md
+++ b/skills/shared/references/plan-templates/extensive.md
@@ -24,25 +24,9 @@ date: YYYY-MM-DD
 
 [Detailed technical design]
 
-### Implementation Phases
+## Implementation Phases
 
-#### Phase 1: [Foundation]
-
-- Tasks and deliverables
-- Phase exit condition
-- Estimated effort
-
-#### Phase 2: [Core Implementation]
-
-- Tasks and deliverables
-- Phase exit condition
-- Estimated effort
-
-#### Phase 3: [Polish & Optimization]
-
-- Tasks and deliverables
-- Phase exit condition
-- Estimated effort
+Embed the block defined in [implementation-phases.md](implementation-phases.md), one phase per split boundary. `/build` executes one phase per context window.
 
 ## Alternative Approaches Considered
 

--- a/skills/shared/references/plan-templates/implementation-phases.md
+++ b/skills/shared/references/plan-templates/implementation-phases.md
@@ -28,13 +28,9 @@ Embed this block verbatim, one `### Phase N` per phase, filling in the placehold
 - **Acceptance criteria:** <observable proof this phase is complete>
 - **Validation:** `<command; exit 0 = pass>` — or `manual <numbered steps>`
 
-### Phase 2: <short name>
+### Phase N: <short name>
 
-- **Status:** Not started
-- **Scope:** <1-2 sentences>
-- **Files touched:** `<path>`, `<path>`
-- **Acceptance criteria:** <observable proof this phase is complete>
-- **Validation:** `<command; exit 0 = pass>` — or `manual <numbered steps>`
+- Same fields as above — one block per phase.
 ```
 
 `**Status:**` starts at `Not started`. `/build` sets it to `Done` after it commits the phase,

--- a/skills/shared/references/plan-templates/implementation-phases.md
+++ b/skills/shared/references/plan-templates/implementation-phases.md
@@ -1,0 +1,42 @@
+# Implementation Phases block
+
+The single source for the `## Implementation Phases` structure. Templates that support
+phased execution embed this block, and `/build` reads it to execute one phase per context
+window.
+
+Phases are optional. A small plan stays single-phase and omits this section — `/build` then
+treats the whole plan as one phase. Add phases when the work is too large to implement well in
+one context window (for example, when the plan-splitting assessment recommends a split and the
+developer keeps a single plan).
+
+Rules:
+
+- Size each phase to fit comfortably in one AI context window.
+- Order phases so the codebase compiles and its tests pass after every phase.
+- Keep each phase self-contained enough to commit on its own.
+
+Embed this block verbatim, one `### Phase N` per phase, filling in the placeholders:
+
+```markdown
+## Implementation Phases
+
+### Phase 1: <short name>
+
+- **Status:** Not started
+- **Scope:** <1-2 sentences on what this phase delivers>
+- **Files touched:** `<path>`, `<path>`
+- **Acceptance criteria:** <observable proof this phase is complete>
+- **Validation:** `<command; exit 0 = pass>` — or `manual <numbered steps>`
+
+### Phase 2: <short name>
+
+- **Status:** Not started
+- **Scope:** <1-2 sentences>
+- **Files touched:** `<path>`, `<path>`
+- **Acceptance criteria:** <observable proof this phase is complete>
+- **Validation:** `<command; exit 0 = pass>` — or `manual <numbered steps>`
+```
+
+`**Status:**` starts at `Not started`. `/build` sets it to `Done` after it commits the phase,
+so progress survives a context clear: on re-entry `/build` resumes at the first phase whose
+status is not `Done`.

--- a/skills/shared/references/plan-templates/standard.md
+++ b/skills/shared/references/plan-templates/standard.md
@@ -24,6 +24,10 @@ date: YYYY-MM-DD
 - Performance implications
 - Security considerations
 
+## Implementation Phases
+
+Optional. Embed the block defined in [implementation-phases.md](implementation-phases.md) when the plan is large enough to warrant phased execution. A small plan omits this section, and `/build` runs it as a single phase.
+
 ## Success Criteria
 
 Embed the machine-checkable block defined in [success-criteria.md](success-criteria.md), with the placeholders filled in.


### PR DESCRIPTION
## Description

Closes #198.

Two planning-workflow pain points: plan quality checks were an optional follow-up that got skipped, and large plans blew the `/build` context window. This folds review into plan creation and teaches `/build` to execute one phase per context window.

**Merge review into `/plan`**

- New shared `skills/shared/references/plan-review.md` runs the simplicity, VGV, and scope-splitting agents in parallel. `/plan` runs it as a mandatory step for standard/extensive plans (skipped for minimal), applying findings to the draft inline before the user sees it.
- On a split recommendation: offer to restructure into phases within one plan, or split into part-N files. No split → the plan stays single-phase.
- `/plan-technical-review` stays as a thin wrapper over the same procedure, for externally-authored plans (plans from `/plan` are already reviewed during creation).

**Phased execution**

- New shared Implementation Phases block (`skills/shared/references/plan-templates/implementation-phases.md`) — per phase: Status, Scope, Files touched, Acceptance criteria, Validation. The standard and extensive templates embed it.
- `/build` loops phases: implement → validate → commit → checkpoint → offer a clear-context handoff → next phase. `Status: Done` markers survive `/clear`, so a resumed build picks up at the first unfinished phase. Plans with no phases build as a single phase (old behavior preserved).

**Commit / push control** (from review feedback)

- Per-phase commits stay automatic (local). Pushing and opening the PR is gated: `/build` confirms first unless the user has a saved auto-push preference (Claude memory / CLAUDE.md).

### Reviewer notes

- Two maintainer decisions were confirmed before finalizing: keep the thin wrapper (vs delete it), and gate push behind confirmation with a preference escape hatch.
- `/hotfix` still auto-pushes — left out of scope here; the same gate can be applied as a follow-up.
- CI-equivalent checks pass locally: markdownlint (0 errors), cspell (0 issues), `claude plugin validate` (passes; only the pre-existing "CLAUDE.md at plugin root" warning), and every skill reference link resolves with no orphaned reference files.

## Type of Change

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)
