### PR TITLE
fix: correct stale plugin and marketplace names in Flutter recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ As simple as this:
 
 ## Better Together: Working With The Very Good AI Flutter Plugin
 
-Wingspan and the [Very Good AI Flutter Plugin](https://github.com/VeryGoodOpenSource/very_good_ai_flutter_plugin) are designed as complementary layers of VGV's AI-assisted engineering stack. The Flutter Plugin embeds battle-tested best practices — architecture patterns, accessibility, testing, performance, and security — directly into Claude Code, so AI-generated code follows VGV's production-quality standards from the first line.
+Wingspan and the [Very Good AI Flutter Plugin](https://github.com/VeryGoodOpenSource/vgv-ai-flutter-plugin) are designed as complementary layers of VGV's AI-assisted engineering stack. The Flutter Plugin embeds battle-tested best practices — architecture patterns, accessibility, testing, performance, and security — directly into Claude Code, so AI-generated code follows VGV's production-quality standards from the first line.
 
 Wingspan operates at a higher level, orchestrating agentic workflows across the full software development lifecycle: planning, code review, brainstorming, and cross-tool coordination. Together, they create a system where Wingspan handles the what and when of engineering work while the Flutter Plugin ensures the how meets enterprise-grade standards — meaning teams don't just move faster, they move faster in the right direction.
 

--- a/hooks/recommendations/vgv-ai-flutter-plugin.json
+++ b/hooks/recommendations/vgv-ai-flutter-plugin.json
@@ -1,11 +1,11 @@
 {
-  "plugin": "very-good-ai-flutter-plugin",
+  "plugin": "vgv-ai-flutter-plugin",
   "detect": [
     { "file": "pubspec.yaml", "pattern": "." },
     { "files": "docs/plan/*.md", "pattern": "flutter|dart" },
     { "files": "docs/brainstorm/*.md", "pattern": "flutter|dart" }
   ],
-  "verificationSkill": "very-good-ai-flutter-plugin:green-gate",
+  "verificationSkill": "vgv-ai-flutter-plugin:green-gate",
   "marketplace": "VeryGoodOpenSource/very_good_claude_code_marketplace",
   "description": "Dart and Flutter best-practice skills (accessibility, BLoC, testing, theming, navigation, security, i18n, architecture) and automated dart analyze/format hooks."
 }

--- a/hooks/recommendations/vgv-ai-flutter-plugin.json
+++ b/hooks/recommendations/vgv-ai-flutter-plugin.json
@@ -6,6 +6,6 @@
     { "files": "docs/brainstorm/*.md", "pattern": "flutter|dart" }
   ],
   "verificationSkill": "vgv-ai-flutter-plugin:green-gate",
-  "marketplace": "VeryGoodOpenSource/very_good_claude_code_marketplace",
+  "marketplace": "VeryGoodOpenSource/very-good-claude-code-marketplace",
   "description": "Dart and Flutter best-practice skills (accessibility, BLoC, testing, theming, navigation, security, i18n, architecture) and automated dart analyze/format hooks."
 }


### PR DESCRIPTION
## Description

The Flutter companion-plugin recommendation carried pre-rename identifiers. Both the plugin and the marketplace repo have since been renamed, so the recommendation hook misfired (#221):

- plugin: `very-good-ai-flutter-plugin` → `vgv-ai-flutter-plugin`
- marketplace repo: `very_good_claude_code_marketplace` → `very-good-claude-code-marketplace`

### Impact

1. **Hook nagged on every tool call.** `is_plugin_installed()` in `hooks/recommend-plugins.sh` greps the user's settings for the `plugin` field value. Installed users have `vgv-ai-flutter-plugin` under `enabledPlugins`, which never matched the old name — so the `PreToolUse` hook injected "The 'very-good-ai-flutter-plugin' … is not installed" on every Read/Glob/Grep in a Flutter project, even when it was installed and enabled.
2. **Broken install instructions.** The recommendation pointed users at `/plugin marketplace add …/very_good_claude_code_marketplace` and `/plugin install very-good-ai-flutter-plugin` — stale slugs that only resolve via GitHub's rename redirect, and a plugin name that resolves to nothing.
3. **Broken ship-gate delegation.** The stale `verificationSkill` prefix meant `/build` and `/hotfix` could never delegate to the plugin's green-gate skill.

### Changes

- Renamed `hooks/recommendations/very-good-ai-flutter-plugin.json` → `vgv-ai-flutter-plugin.json`, and within it:
  - `plugin`: `very-good-ai-flutter-plugin` → `vgv-ai-flutter-plugin`
  - `verificationSkill`: `very-good-ai-flutter-plugin:green-gate` → `vgv-ai-flutter-plugin:green-gate`
  - `marketplace`: `VeryGoodOpenSource/very_good_claude_code_marketplace` → `VeryGoodOpenSource/very-good-claude-code-marketplace`
- `README.md`: the "Very Good AI Flutter Plugin" link pointed at the old repo slug `very_good_ai_flutter_plugin`; now points at the canonical `vgv-ai-flutter-plugin` repo.

`CHANGELOG.md` still names the old identifiers in past entries — left untouched as immutable release history.

### Verification

- `hooks/test_recommend_plugins.sh`: **42 passed, 0 failed**.
- Ran `hooks/recommend-plugins.sh` against a Flutter project both ways:
  - plugin enabled → hook exits silently (the bug: it used to nag).
  - plugin not installed → recommends `vgv-ai-flutter-plugin` and points `/plugin marketplace add` at `very-good-claude-code-marketplace` — both canonical slugs.

Closes #221

## Type of Change

<!--- Check the one that applies to this PR. -->

- [ ] New feature (`feat`)
- [x] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [x] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)