### PR TITLE
feat(skills): add /split-pr skill for stacked pull requests

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -17,6 +17,8 @@
     "planning",
     "ai assisted engineering",
     "sdlc",
-    "software development lifecyle"
+    "software development lifecyle",
+    "stacked pull requests",
+    "code review"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Wingspan operates at a higher level, orchestrating agentic workflows across the 
 | [**Hotfix**](skills/hotfix/SKILL.md) | `/hotfix <bug description>` | Apply a minimal, targeted fix for emergency bugs — enforces review and testing without brainstorm or planning |
 | [**Create**](skills/create/SKILL.md) | `/create <what to create>` | Scaffold a new project by routing to the right companion plugin |
 | [**Create PR**](skills/create-pr/SKILL.md) | `/create-pr` | Validate (formatter, linter, tests, and CI checks), stage, commit, push, and open a pull request on the project's Git hosting platform — aborts on any failure |
+| [**Split PR**](skills/split-pr/SKILL.md) | `/split-pr [branch, PR number, or PR URL]` | Split a large branch or pull request into a stack of smaller, independently-reviewable pull requests |
 | [**Rebase**](skills/rebase/SKILL.md) | `/rebase` | Rebase the current feature branch onto the base branch to stay up-to-date |
 | [**Debrief**](skills/debrief/SKILL.md) | `/debrief <incident or context>` | Produce a structured post-incident analysis — timeline, root cause, and actionable follow-ups |
 

--- a/config/cspell.json
+++ b/config/cspell.json
@@ -24,7 +24,10 @@
     "undiscussed",
     "unrequested",
     "pipefail",
-    "runnable"
+    "runnable",
+    "unstack",
+    "retarget",
+    "reflog"
   ],
   "flagWords": []
 }

--- a/skills/split-pr/SKILL.md
+++ b/skills/split-pr/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: split-pr
+user-invocable: true
+description: Split a large branch or open pull request into a stack of smaller, independently-reviewable pull requests. Works on existing code changes only, not on plans or specs.
+when_to_use: Use when the user says "split this PR", "break up this branch", "this PR is too big", "chunk these changes into smaller PRs", or pastes a PR URL and asks for it to be split.
+argument-hint: "[optional: branch name, PR number, or PR URL]"
+allowed-tools: Bash(*/scripts/detect-base-branch.sh) Bash(*/scripts/split-inventory.sh) Bash(git *) Bash(gh *) Bash(glab *)
+effort: high
+compatibility: Designed for Claude Code (or similar products with git access)
+---
+
+# Split a pull request
+
+Break a large branch or open pull request into a stack of smaller pull requests that each tell one story and can be reviewed on their own.
+
+## Steps checklist
+
+- [ ] Step 0: Parse arguments
+- [ ] Step 1: Validate preconditions
+- [ ] Step 2: Inventory the diff
+- [ ] Step 3: Group the changes
+- [ ] Step 4: Propose the split and get approval
+- [ ] Step 5: Build the stack
+- [ ] Step 6: Verify each branch
+- [ ] Step 7: Publish
+
+## Important
+
+- The source branch is read-only. Nothing here writes to it, and Step 6 checks that it did not move.
+- Do not create any branch before the user approves the plan in Step 4.
+- Do not push or open pull requests before the user confirms in Step 7.
+
+## Context
+
+<context>$ARGUMENTS</context>
+
+This may be a branch name, a pull request number or URL, or empty.
+
+## Step 0: Parse arguments
+
+| Argument | Action |
+| -------- | ------ |
+| Branch name | Use it as `SOURCE_BRANCH`. |
+| PR number or URL | Resolve the head branch and target branch from the platform (`gh pr view <ref> --json headRefName,baseRefName`). |
+| Empty | Use the current branch as `SOURCE_BRANCH`. |
+
+## Step 1: Validate preconditions
+
+Run in parallel:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git status --porcelain
+${CLAUDE_SKILL_DIR}/scripts/detect-base-branch.sh
+```
+
+Stop and tell the user if any of these hold:
+
+- `SOURCE_BRANCH` is the base branch — there is nothing to split.
+- The working tree is dirty. Splitting checks out branches, so it needs a clean tree. Offer to commit or stash first.
+- The base branch could not be detected. Ask the user which branch the work targets.
+
+Store the detected base as `BASE_BRANCH`, overriding it with the pull request's target branch when Step 0 resolved one.
+
+Record the source tip, so Step 6 can prove it never moved:
+
+```bash
+git rev-parse <SOURCE_BRANCH>
+```
+
+Store it as `SOURCE_SHA`.
+
+Fetch so the comparison runs against current refs:
+
+```bash
+git fetch origin
+```
+
+## Step 2: Inventory the diff
+
+```bash
+${CLAUDE_SKILL_DIR}/scripts/split-inventory.sh <BASE_BRANCH> <SOURCE_BRANCH>
+```
+
+The script reports `MEANINGFUL_LINES`, `GENERATED_LINES`, and a per-file record of added and deleted lines classified as `source` or `generated`. Use `MEANINGFUL_LINES` for every size judgment — generated output inflates a diff without adding anything for a reviewer to read.
+
+If `MEANINGFUL_LINES` is under 500, say so and ask whether the user still wants to split. A small branch usually should not be.
+
+Then read the diff itself:
+
+```bash
+git log <BASE_BRANCH>..<SOURCE_BRANCH> --oneline
+git diff <BASE_BRANCH>...<SOURCE_BRANCH>
+```
+
+Filenames alone are not enough. Read the changes to learn what each file does and which files reference each other — that is what determines whether two files can land separately.
+
+## Step 3: Group the changes
+
+Apply the [splitting heuristics](references/heuristics.md) to turn the file list into an ordered set of pull requests. That reference holds the size targets, the boundaries worth splitting on, the signals that a group should stay whole, and how to break down a layer that is still too large.
+
+Every group must satisfy all of:
+
+- It builds and passes its own tests without any later group.
+- Its meaningful diff is under the size ceiling in the heuristics reference.
+- It has one describable purpose.
+
+## Step 4: Propose the split and get approval
+
+Present the plan before touching any branch. For each proposed pull request give the title, the files, the meaningful line count, a one-sentence description, and which group it depends on.
+
+```markdown
+## Proposed split — 6 PRs from 2,340 meaningful lines
+
+### 1. Add settings API endpoints
+`src/api/settings.ts`, `src/api/settings.test.ts`
+~120 lines · depends on: nothing
+Adds the endpoints the feature calls. No business logic or interface code.
+
+### 2. Add user profile model
+`src/models/profile.ts`, `src/models/profile.test.ts`
+~350 lines · depends on: 1
+Core model the profile screen and the repository both need.
+
+## Stack order
+main → 1 → 2 → 3 → 4 → 5 → 6
+```
+
+Then ask, with **AskUserQuestion**:
+
+**Question:** "Here is how I would split this. Does the grouping work?"
+
+**Options:**
+
+1. **Approve** — build the stack as proposed.
+2. **Move files** — ask which files belong in which pull request, revise, ask again.
+3. **Cancel** — stop without changing anything.
+
+Tell the user the source branch is left untouched and that every group lands on a new branch, so nothing they have now is rewritten.
+
+**Do not proceed without approval.**
+
+## Step 5: Build the stack
+
+Each branch starts from the branch below it, not from the base. That is what makes the result a stack: every pull request shows only its own changes rather than repeating everything underneath.
+
+For the first group:
+
+```bash
+git checkout -b <branch-1> <BASE_BRANCH>
+```
+
+For each subsequent group:
+
+```bash
+git checkout -b <branch-n> <branch-n-minus-1>
+```
+
+Populate each branch by whichever of these fits:
+
+| Situation | Approach |
+| --------- | -------- |
+| Commits already map to the groups | `git cherry-pick <commit>...` |
+| Commits are mixed across groups | `git checkout <SOURCE_BRANCH> -- <files>`, then commit |
+| One file spans two groups | Check the file out, then edit it down to only this group's changes |
+
+Commit each branch with a message describing that group alone, following whatever commit convention the project already uses. Infer it from `git log <BASE_BRANCH> --oneline -20`.
+
+Watch for these while building:
+
+- **Partial files.** A file whose hunks belong to different groups has to be split by hand. Check it out from the source branch, then remove the hunks that belong later. Re-read the result before committing.
+- **Generated output.** Include only the generated files matching source files in the same group, or leave generated files out entirely and regenerate after the stack lands. Never let a generated file arrive before the source that produces it.
+- **Tests travel with their code.** Never separate an implementation from its tests.
+- **Changes already on the base.** A branch that absorbed the base through a merge commit carries changes that are not part of the feature. Leave them out and say so.
+
+## Step 6: Verify each branch
+
+For each branch, from the bottom of the stack up:
+
+```bash
+git checkout <branch-n>
+git diff <parent-branch>...<branch-n> --stat
+```
+
+Confirm that only the intended files appear and that nothing leaked in from an adjacent group. Then run the project's build and test commands on each branch. A branch that does not pass on its own is not independently mergeable — fold it into its neighbor or move the missing file into it, and re-verify.
+
+Then confirm the source branch never moved:
+
+```bash
+git rev-parse <SOURCE_BRANCH>
+```
+
+This must still equal `SOURCE_SHA` from Step 1. Nothing in Step 5 writes to the source branch, so a different value means a command went to the wrong branch. Stop and tell the user, and recover the original tip from `git reflog <SOURCE_BRANCH>`.
+
+Then prove nothing was lost, by diffing the top of the stack against the source branch:
+
+```bash
+git diff <top-branch> <SOURCE_BRANCH> --stat
+```
+
+Empty output means the stack reproduces the original exactly. Anything listed is a change that reached no group. Account for every line: generated files left out on purpose belong here, an overlooked source file is a bug in the split. Report whatever remains either way.
+
+Report any branch you could not verify, and why.
+
+## Step 7: Publish
+
+Ask, with **AskUserQuestion**, whether to push the branches and open the pull requests. On **No**, stop and summarize the local branches so the user can publish by hand.
+
+On **Yes**, consult the [stacked pull requests reference](references/stacked-prs.md). It detects whether GitHub's native stacked pull requests are available and gives both paths: the `gh stack` commands that adopt these branches into a real stack, and the manual parent-targeted fallback for GitLab, older CLIs, or repositories without the feature.
+
+Finish with a summary listing each pull request, its base, and the merge order, and confirm the source branch is unchanged at `SOURCE_SHA`.

--- a/skills/split-pr/references/heuristics.md
+++ b/skills/split-pr/references/heuristics.md
@@ -1,0 +1,59 @@
+# Splitting Heuristics
+
+How to turn one large diff into an ordered set of pull requests.
+
+## Size targets
+
+Measure against `MEANINGFUL_LINES` from `scripts/split-inventory.sh`, which excludes generated output.
+
+| Range | Verdict |
+| ----- | ------- |
+| Under 500 lines | Ideal. A reviewer finishes it in one sitting. |
+| 500–1,500 lines | Acceptable only when the code is repetitive or formulaic, such as a set of near-identical mappers. |
+| Over 1,500 lines | Split further. |
+
+Never propose a group over 1,500 lines without first trying to break it down. "All of the interface code" is not a valid unit if it exceeds the ceiling.
+
+## Split on these boundaries
+
+| Boundary | Example |
+| -------- | ------- |
+| Architectural layer | Data access, then business logic, then interface |
+| Feature or domain | Auth changes separate from settings changes |
+| Dependency direction | The shared utility first, then the code calling it |
+| Sub-feature within a layer | One screen or endpoint per pull request |
+| Independence | Two groups that never reference each other need not be stacked at all |
+
+## Always split out
+
+- **Infrastructure and configuration** — CI, build config, dependency bumps. Fast to review and often blocking other work.
+- **Shared additions** — new helpers, shared components, client methods. Land the foundation before its consumers.
+- **Refactors mixed with features** — refactor first, feature second. A diff that both moves code and changes behavior hides the behavior change.
+
+## Keep a group whole when
+
+- The files import each other directly and were changed as one unit.
+- It is a model plus the single consumer that uses it, and the total is under 500 lines.
+- It is a small bug fix touching a handful of files. Do not split a 30-line fix into three pull requests.
+
+## Split a group further when
+
+- Its meaningful diff exceeds 500 lines.
+- Its files serve clearly different purposes, such as client code beside interface code beside configuration.
+- A reviewer would have to context-switch to follow different parts of it.
+- It contains several independent sub-features.
+
+## Breaking down a layer that is still too large
+
+| Layer | How to divide it |
+| ----- | ---------------- |
+| Business logic or domain | By related model cluster. A contract or interface goes with the cluster it serves most, or alone if large. |
+| Data access | By mapper or adapter group, each with its tests. The implementation that wires them lands after. |
+| Interface | By screen or component, each with its state management and tests. Scaffolding — package config, shared test helpers, the barrel or index file — goes in the first one. |
+| Application wiring | Routing separately from dependency injection, or one entry point at a time. |
+
+Splitting inside a layer produces temporary partial states: an index file exporting three of five modules, a translation file holding only some strings. That is fine. Each pull request must build and pass its own tests, but it does not have to represent the finished feature.
+
+## Reordering to shrink the stack
+
+A stack is only as parallel as its dependencies allow. Before settling on an order, check whether any group actually depends on the one below it. Groups with no relationship between them can start from the base branch instead, giving independent pull requests that review and merge in parallel rather than a chain that merges strictly bottom-up.

--- a/skills/split-pr/references/stacked-prs.md
+++ b/skills/split-pr/references/stacked-prs.md
@@ -1,0 +1,126 @@
+# Stacked Pull Requests Reference
+
+How to publish the branches built in Step 6 as pull requests, using GitHub's native stacked pull requests when they are available.
+
+## Detect the available path
+
+Run in parallel:
+
+```bash
+gh --version 2>/dev/null
+glab --version 2>/dev/null
+gh extension list 2>/dev/null
+```
+
+| Result | Path |
+| ------ | ---- |
+| `gh` present and `gh-stack` listed | **Native stack** below. |
+| `gh` present, `gh-stack` missing | Offer to install it: `gh extension install github/gh-stack`. On decline, use the **manual fallback**. |
+| Only `glab`, or neither | **Manual fallback**. GitLab has no equivalent of GitHub stacks. |
+
+GitHub's stacked pull requests are in public preview. If a `gh stack` command fails because the feature is unavailable for the repository, fall back to the manual path and tell the user why rather than retrying.
+
+## Native stack
+
+Stacks require every branch to live in the **same repository**. Cross-fork stacks are not supported, so a contributor working from a fork must use the manual fallback.
+
+### Adopt the branches
+
+The branches already exist locally, so adopt them rather than authoring a new stack. Pass them bottom-to-top:
+
+```bash
+gh stack init --base <BASE_BRANCH> <branch-1> <branch-2> <branch-3>
+```
+
+Verify the order before going further:
+
+```bash
+gh stack view
+```
+
+The output lists the branches from trunk upward. If the order is wrong, fix it with `gh stack modify` — it needs a clean working tree and no rebase in progress.
+
+### Open the pull requests
+
+```bash
+gh stack submit
+```
+
+This pushes every branch and creates a pull request per branch, each targeting the branch below it, wired together as a stack on GitHub.
+
+Run it **without `--auto`**. In an interactive terminal `submit` opens an editor where each pull request's title and description can be set, which is where the titles agreed in Step 4 go. `--auto` skips that editor and substitutes auto-generated titles, discarding the ones the user just approved — reach for it only in a non-interactive session, and say so when you do.
+
+| Flag | Effect |
+| ---- | ------ |
+| none | Interactive editor. New pull requests default to ready for review. |
+| `--auto` | No editor, auto-generated titles, created as drafts. |
+| `--open` | Mark new and existing pull requests ready for review. Pair with `--auto` to avoid drafts. |
+
+To publish only part of the stack, deselect branches in the editor with `Ctrl+X`. Deselecting a branch also deselects everything above it, since a pull request cannot target an unpublished branch.
+
+### What the user gets
+
+GitHub renders the stack on each pull request, so the position and dependencies are visible without a hand-written merge guide. Pull requests merge bottom-up: merging one mid-stack also merges everything below it, and the ones above automatically retarget. There is no manual retargeting to do.
+
+### Useful follow-ups
+
+| Command | Use |
+| ------- | --- |
+| `gh stack view` | Show the stack, its pull requests, and each branch's position. |
+| `gh stack sync` | Fetch, fast-forward trunk, cascade-rebase the stack, push, and reconcile pull request state. |
+| `gh stack rebase` | Cascade-rebase after the base branch moves. `--continue` and `--abort` handle conflicts. |
+| `gh stack merge <pr>` | Merge every pull request up to and including `<pr>`. All-or-nothing. `--squash`, `--merge`, `--rebase` pick the method. |
+| `gh stack unstack --local` | Stop tracking the stack locally without changing it on GitHub. |
+
+Mention `gh stack sync` to the user in the closing summary. Review feedback on a lower pull request is the normal case, and after amending it the stack above needs a cascade-rebase to stay consistent.
+
+Do not run `gh stack merge` as part of this skill. Merging is the user's call after review.
+
+## Manual fallback
+
+Without stack support, reproduce the shape by hand: each pull request targets the branch below it.
+
+### Push
+
+```bash
+git push -u origin <branch-n>
+```
+
+### Open each pull request
+
+Bottom to top, so each target branch exists before the pull request pointing at it:
+
+| CLI | Command |
+| --- | ------- |
+| `gh` | `gh pr create --title "<title>" --body "<body>" --base <parent-branch>` |
+| `glab` | `glab mr create --title "<title>" --description "<body>" --target-branch <parent-branch>` |
+| neither | Output the titles and bodies as Markdown for the user to open by hand. |
+
+Use the repository's pull request template when one exists at `.github/PULL_REQUEST_TEMPLATE.md`, `.github/pull_request_template.md`, or `docs/pull_request_template.md`.
+
+In each body, state the position and the dependency explicitly, since nothing renders it automatically:
+
+```markdown
+Part 2 of 6. Depends on #101.
+```
+
+Some teams also put the position in the title, such as `feat: (2/6) add user profile model`. Follow the convention already visible in the repository's recent pull requests rather than introducing one.
+
+### Merge guide
+
+Close with the order, because the platform will not track it:
+
+```markdown
+## Merge order
+
+1. #101 — API endpoints → base `main`
+2. #102 — user profile model → base `<branch-1>`, retarget to `main` after #101 merges
+3. #103 — settings interface → base `<branch-2>`, retarget to `main` after #102 merges
+
+Retarget each pull request to `main` once the one below it merges. Repositories with
+"automatically retarget" enabled do this for you.
+
+`<SOURCE_BRANCH>` is unchanged and can be deleted once the stack lands.
+```
+
+Warn the user that a squash merge on a lower pull request rewrites its commits, which orphans the branch above it. After each squash merge, the next branch needs `git rebase --onto main <old-parent> <branch>` before it will show a clean diff.

--- a/skills/split-pr/scripts/detect-base-branch.sh
+++ b/skills/split-pr/scripts/detect-base-branch.sh
@@ -1,0 +1,1 @@
+../../shared/scripts/detect-base-branch.sh

--- a/skills/split-pr/scripts/split-inventory.sh
+++ b/skills/split-pr/scripts/split-inventory.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Inventory the diff between a base branch and a source branch.
+#
+# Usage: split-inventory.sh <base-branch> <source-branch>
+#
+# Outputs KEY=value summary lines, then a FILES section with one
+# tab-separated record per changed file:
+#
+#   <path>\t<added>\t<deleted>\t<generated|source>
+#
+# Files are classified as generated when the repository marks them
+# linguist-generated, or when they match a common lockfile or codegen
+# pattern. Generated lines are excluded from the meaningful totals so
+# size targets reflect what a reviewer actually reads.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "ERROR: usage: split-inventory.sh <base-branch> <source-branch>" >&2
+  exit 1
+fi
+
+BASE="$1"
+SOURCE="$2"
+
+for ref in "$BASE" "$SOURCE"; do
+  if ! git rev-parse --verify "$ref" &>/dev/null; then
+    echo "ERROR: ref not found: $ref" >&2
+    exit 1
+  fi
+done
+
+MERGE_BASE="$(git merge-base "$BASE" "$SOURCE")"
+
+is_generated() {
+  local path="$1"
+
+  local attr
+  attr="$(git check-attr linguist-generated -- "$path" 2>/dev/null | sed 's/.*: //')"
+  if [[ "$attr" == "set" || "$attr" == "true" ]]; then
+    return 0
+  fi
+
+  case "$(basename "$path")" in
+    package-lock.json | yarn.lock | pnpm-lock.yaml | Gemfile.lock | \
+      Cargo.lock | poetry.lock | composer.lock | go.sum | pubspec.lock | \
+      Package.resolved | uv.lock)
+      return 0
+      ;;
+  esac
+
+  case "$path" in
+    *.g.dart | *.freezed.dart | *.gen.dart | *.mocks.dart | *.pb.go | \
+      *_pb2.py | *.generated.* | *.designer.cs | *.snap | *generated/* | \
+      */__generated__/* | */migrations/*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+total_files=0
+meaningful=0
+generated=0
+records=""
+
+while IFS=$'\t' read -r added deleted path; do
+  [[ -z "${path:-}" ]] && continue
+
+  # Binary files report "-" instead of a line count.
+  [[ "$added" == "-" ]] && added=0
+  [[ "$deleted" == "-" ]] && deleted=0
+
+  total_files=$((total_files + 1))
+  churn=$((added + deleted))
+
+  if is_generated "$path"; then
+    generated=$((generated + churn))
+    records+="${path}	${added}	${deleted}	generated"$'\n'
+  else
+    meaningful=$((meaningful + churn))
+    records+="${path}	${added}	${deleted}	source"$'\n'
+  fi
+done < <(git diff --numstat "$MERGE_BASE" "$SOURCE")
+
+commits="$(git rev-list --count "$MERGE_BASE".."$SOURCE")"
+
+echo "BASE=${BASE}"
+echo "SOURCE=${SOURCE}"
+echo "MERGE_BASE=${MERGE_BASE}"
+echo "COMMITS=${commits}"
+echo "TOTAL_FILES=${total_files}"
+echo "MEANINGFUL_LINES=${meaningful}"
+echo "GENERATED_LINES=${generated}"
+echo "FILES"
+printf '%s' "$records"


### PR DESCRIPTION
## Description

Wingspan can already tell you a plan is too big before you build it. Nothing helps once the code exists. This adds the skill for that case and publishes the result through GitHub's stacked pull requests.

**How this differs from the plan-splitting agent (#60)**

The two are complementary and never overlap — they act at opposite ends of the workflow, on different inputs, with different outputs.

| | `plan-splitting-agent` (#60) | `/split-pr` (this PR) |
| --- | --- | --- |
| Input | A plan file in `docs/plan/` | An existing branch, PR number, or PR URL |
| When | Before any code is written | After the branch has already grown |
| Reads | Prose describing intended work | The real diff, file by file |
| Sizing | Estimated LOC impact | Measured lines, generated files excluded |
| Output | A recommendation, plus phases or part-N files | Branches, commits, and open pull requests |
| Dispatched by | `/plan` and `/plan-technical-review` | The user, directly |

The agent prevents oversized PRs. The skill remediates the ones that got through — a branch that skipped `/plan`, grew past its estimate, or arrived from outside the Wingspan workflow. Neither can do the other's job: the agent has no diff to read and creates no branches, and the skill has no plan to restructure.

`/split-pr` therefore works on existing code changes only, and its description says so explicitly so it never triggers on a plan or spec.

**The workflow**

Seven steps, gated so nothing is created or pushed without confirmation:

- **Inventory** — `scripts/split-inventory.sh` reports per-file added/deleted counts and classifies each file as source or generated, via `linguist-generated`, lockfile names, and common codegen patterns. Size targets are measured against meaningful lines, so a diff dominated by generated output isn't mistaken for a large change.
- **Group** — `references/heuristics.md` holds the size targets (under 500 ideal, 1,500 ceiling), the boundaries worth splitting on, the signals a group should stay whole, and how to break down a layer that is still too large.
- **Propose** — the split is presented for approval before any branch exists. Nothing is created until the user approves.
- **Build** — each branch is created from the branch below it rather than from the base, so every pull request shows only its own diff.
- **Verify** — each branch is built and tested on its own, then the top of the stack is diffed against the source branch to prove no change was dropped.

**Publishing through `gh stack`**

`references/stacked-prs.md` detects whether the `gh-stack` extension is available, then adopts the branches with `gh stack init --base <trunk> <branches...>` and opens the pull requests with `gh stack submit`. GitHub renders stack position on each pull request and retargets the layers above as lower ones merge, which removes the hand-written merge guide and the manual `--base` bookkeeping the workflow would otherwise need.

`submit` is documented without `--auto` on purpose: `--auto` substitutes auto-generated titles and would discard the ones the user just approved.

The fallback path covers GitLab, a missing extension, and repositories without the preview enabled — parent-targeted pull requests, an explicit merge order, and a warning that squash-merging a lower pull request orphans the branch above it and needs `git rebase --onto`.

**The source branch is guarded by an invariant, not a backup**

Nothing in the workflow writes to the source branch, so Step 1 records its tip and Step 6 asserts it has not moved, pointing at `git reflog` for recovery. A backup branch was the first design and was dropped: it protected against nothing on any documented path, left a stray ref behind, and made a second run fail outright on the existing name.

### Reviewer notes

- **Model invocation is left enabled**, unlike `/rebase` and `/create-pr`. Much of the value is auto-triggering on "this PR is too big", and the skill cannot mutate anything before the Step 4 approval gate. Happy to add `disable-model-invocation` if you'd rather it stay consistent with the other git skills.
- **`gh stack modify` overlaps slightly.** Someone who has already split their work and only wants to reorder or fold layers should use the extension directly. I can add a line to the skill pointing that case away from `/split-pr`.
- **No shared reference was added.** The skill wanted `create-pr/references/conventional-commits.md`, but that path escapes the skill directory and fails `reference-exists`. Rather than move it to `skills/shared/` and widen this PR past one skill, the commit guidance is inlined. Worth promoting to shared separately if another skill needs it.
- `scripts/detect-base-branch.sh` is symlinked from `skills/shared/scripts/` per CONTRIBUTING, stored as mode `120000`.
- CI-equivalent checks pass locally: markdownlint (0 issues), cspell (0 issues, `unstack`/`retarget`/`reflog` added to `config/cspell.json`), `claude plugin validate` (passes; only the pre-existing "CLAUDE.md at plugin root" warning, which reproduces on a clean `main`), and both reference links resolve.
- `split-inventory.sh` was exercised against fixtures covering `linguist-generated` attributes, lockfiles, codegen paths, binary files, and a bad ref. The seven-step workflow was run end to end on a synthetic repository: each branch showed only its own diff, the invariant fired when a stray commit was planted on the source branch, and `git reflog` returned the recorded tip.

## Type of Change

- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Code refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] CI change (`ci`)
- [ ] Chore (`chore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
